### PR TITLE
Set the correct IDP as the authenticating authority

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
@@ -150,7 +150,7 @@ class ProxyResponseService
         $newAssertion->setAuthenticatingAuthority(
             array_merge(
                 (empty($authority) ? [] : $authority),
-                [$this->hostedIdentityProvider->getEntityId()]
+                [$assertion->getIssuer()]
             )
         );
     }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
@@ -36,12 +36,6 @@ use Surfnet\StepupGateway\SamlStepupProviderBundle\Saml\StateHandler;
 
 final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
 {
-    const IDENTITY_PROVIDER_ENTITY_ID = 'https://gateway.pilot.stepup.surfconext.nl/authentication/metadata';
-
-    const ISSUER = 'https://engine.surfconext.nl/authentication/idp/metadata';
-
-    const EXISTING_AUTHENTICATING_AUTHORITY = 'https://www.onegini.me/';
-
     /**
      * @var Mockery\MockInterface|IdentityProvider
      */
@@ -90,7 +84,7 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
         $container = new TestSaml2Container(new NullLogger());
         SAML2_Compat_ContainerSingleton::setContainer($container);
 
-        $this->identityProvider->shouldReceive('getEntityId')->andReturn(self::IDENTITY_PROVIDER_ENTITY_ID);
+        $this->identityProvider->shouldReceive('getEntityId')->andReturn('https://gateway.example/metadata');
         $this->attributeDictionary->shouldReceive('translate->getAttributeValue')->andReturnNull();
     }
 
@@ -109,7 +103,7 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
         );
 
         $originalAssertion = new SAML2_Assertion();
-        $originalAssertion->setIssuer(self::ISSUER);
+        $originalAssertion->setIssuer('https://idp.example/metadata');
 
         $response = $factory->createProxyResponse($originalAssertion, $this->targetServiceProvider);
 
@@ -119,7 +113,7 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(SAML2_Assertion::class, $assertion);
 
         $this->assertEquals(
-            [self::ISSUER],
+            ['https://idp.example/metadata'],
             $assertion->getAuthenticatingAuthority()
         );
     }
@@ -139,8 +133,8 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
         );
 
         $originalAssertion = new SAML2_Assertion();
-        $originalAssertion->setIssuer(self::ISSUER);
-        $originalAssertion->setAuthenticatingAuthority([self::EXISTING_AUTHENTICATING_AUTHORITY]);
+        $originalAssertion->setIssuer('https://idp.example/metadata');
+        $originalAssertion->setAuthenticatingAuthority(['https://previous.idp.example/metadata']);
 
         $response = $factory->createProxyResponse($originalAssertion, $this->targetServiceProvider);
 
@@ -150,7 +144,7 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(SAML2_Assertion::class, $assertion);
 
         $this->assertEquals(
-            [self::EXISTING_AUTHENTICATING_AUTHORITY, self::ISSUER],
+            ['https://previous.idp.example/metadata', 'https://idp.example/metadata'],
             $assertion->getAuthenticatingAuthority()
         );
     }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
@@ -97,7 +97,7 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldSetProxiedIdentityProviderAsAuthenticatingAuthority()
+    public function it_sets_the_proxied_identity_provider_as_authenticating_authority()
     {
         $factory = new ProxyResponseService(
             $this->identityProvider,
@@ -127,7 +127,7 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldAppendProxiedIdentityProviderToExistingAuthenticatingAuthorities()
+    public function it_appends_the_proxied_identity_provider_to_existing_authenticating_authorities()
     {
         $factory = new ProxyResponseService(
             $this->identityProvider,

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Tests\Service;
+
+use Mockery;
+use PHPUnit_Framework_TestCase;
+use Psr\Log\NullLogger;
+use SAML2_Assertion;
+use SAML2_Compat_ContainerSingleton;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Surfnet\SamlBundle\Tests\TestSaml2Container;
+use Surfnet\StepupBundle\Value\Loa;
+use Surfnet\StepupGateway\GatewayBundle\Entity\ServiceProvider;
+use Surfnet\StepupGateway\GatewayBundle\Saml\AssertionSigningService;
+use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
+use Surfnet\StepupGateway\GatewayBundle\Service\ProxyResponseService;
+use Surfnet\StepupGateway\SamlStepupProviderBundle\Saml\StateHandler;
+
+final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
+{
+    const ISSUER = 'https://engine.surfconext.nl/authentication/idp/metadata';
+
+    const EXISTING_AUTHENTICATING_AUTHORITY = 'https://www.onegini.me/';
+
+    /**
+     * @var Mockery\MockInterface|IdentityProvider
+     */
+    private $identityProvider;
+
+    /**
+     * @var Mockery\MockInterface|StateHandler
+     */
+    private $proxyStateHandler;
+
+    /**
+     * @var Mockery\MockInterface|AssertionSigningService
+     */
+    private $assertionSigningService;
+
+    /**
+     * @var Mockery\MockInterface|ServiceProvider
+     */
+    private $targetServiceProvider;
+
+    /**
+     * @var Mockery\MockInterface|AttributeDictionary
+     */
+    private $attributeDictionary;
+
+    /**
+     * @var Mockery\MockInterface|AttributeDefinition
+     */
+    private $attributeDefinition;
+
+    /**
+     * @var Loa
+     */
+    private $loa;
+
+    protected function setUp()
+    {
+        $this->identityProvider = Mockery::mock(IdentityProvider::class)->shouldIgnoreMissing();
+        $this->proxyStateHandler = Mockery::mock(ProxyStateHandler::class)->shouldIgnoreMissing();
+        $this->assertionSigningService = Mockery::mock(AssertionSigningService::class)->shouldIgnoreMissing();
+        $this->attributeDictionary = Mockery::mock(AttributeDictionary::class);
+        $this->attributeDefinition = Mockery::mock(AttributeDefinition::class);
+        $this->loa = Mockery::mock(Loa::class);
+        $this->targetServiceProvider = Mockery::mock(ServiceProvider::class)->shouldIgnoreMissing();
+
+        $container = new TestSaml2Container(new NullLogger());
+        SAML2_Compat_ContainerSingleton::setContainer($container);
+
+        $this->attributeDictionary->shouldReceive('translate->getAttributeValue')->andReturnNull();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetProxiedIdentityProviderAsAuthenticatingAuthority()
+    {
+        $factory = new ProxyResponseService(
+            $this->identityProvider,
+            $this->proxyStateHandler,
+            $this->assertionSigningService,
+            $this->attributeDictionary,
+            $this->attributeDefinition,
+            $this->loa
+        );
+
+        $originalAssertion = new SAML2_Assertion();
+        $originalAssertion->setIssuer(self::ISSUER);
+
+        $response = $factory->createProxyResponse($originalAssertion, $this->targetServiceProvider);
+
+        /** @var SAML2_Assertion $assertion */
+        $assertion = $response->getAssertions()[0];
+
+        $this->assertInstanceOf(SAML2_Assertion::class, $assertion);
+
+        $this->assertEquals(
+            [self::ISSUER],
+            $assertion->getAuthenticatingAuthority()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAppendProxiedIdentityProviderToExistingAuthenticatingAuthorities()
+    {
+        $factory = new ProxyResponseService(
+            $this->identityProvider,
+            $this->proxyStateHandler,
+            $this->assertionSigningService,
+            $this->attributeDictionary,
+            $this->attributeDefinition,
+            $this->loa
+        );
+
+        $originalAssertion = new SAML2_Assertion();
+        $originalAssertion->setIssuer(self::ISSUER);
+        $originalAssertion->setAuthenticatingAuthority([self::EXISTING_AUTHENTICATING_AUTHORITY]);
+
+        $response = $factory->createProxyResponse($originalAssertion, $this->targetServiceProvider);
+
+        /** @var SAML2_Assertion $assertion */
+        $assertion = $response->getAssertions()[0];
+
+        $this->assertInstanceOf(SAML2_Assertion::class, $assertion);
+
+        $this->assertEquals(
+            [self::EXISTING_AUTHENTICATING_AUTHORITY, self::ISSUER],
+            $assertion->getAuthenticatingAuthority()
+        );
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
@@ -36,6 +36,8 @@ use Surfnet\StepupGateway\SamlStepupProviderBundle\Saml\StateHandler;
 
 final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
 {
+    const IDENTITY_PROVIDER_ENTITY_ID = 'https://gateway.pilot.stepup.surfconext.nl/authentication/metadata';
+
     const ISSUER = 'https://engine.surfconext.nl/authentication/idp/metadata';
 
     const EXISTING_AUTHENTICATING_AUTHORITY = 'https://www.onegini.me/';
@@ -88,6 +90,7 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
         $container = new TestSaml2Container(new NullLogger());
         SAML2_Compat_ContainerSingleton::setContainer($container);
 
+        $this->identityProvider->shouldReceive('getEntityId')->andReturn(self::IDENTITY_PROVIDER_ENTITY_ID);
         $this->attributeDictionary->shouldReceive('translate->getAttributeValue')->andReturnNull();
     }
 


### PR DESCRIPTION
Instead of setting Gateway itself as the authenticating authority, use the issuer of the original SAML assertion.

Fixes [#137529593](https://www.pivotaltracker.com/story/show/137529593)