### PR TITLE
Missing EPTI attribute results in Assertion without Subject

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2015-07-28T16:57:54Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2017-05-23T15:17:23Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -43,8 +43,8 @@
         <target>If you think this error is a mistake, please report it to SURFnet, along with the above error code.</target>
       </trans-unit>
       <trans-unit id="b0c6c739ae28f825ab8beb19b0ac2a2fe3318c8b" resname="gateway.error.text.your_art_code">
-        <jms:reference-file line="12">views/Exception/error.html.twig</jms:reference-file>
         <jms:reference-file line="12">views/Exception/error404.html.twig</jms:reference-file>
+        <jms:reference-file line="12">views/Exception/error.html.twig</jms:reference-file>
         <source>gateway.error.text.your_art_code</source>
         <target>The error code for the error is</target>
       </trans-unit>
@@ -62,6 +62,11 @@
         <jms:reference-file line="7">views/Gateway/unrecoverableError.html.twig</jms:reference-file>
         <source>gateway.error.unrecoverable_error</source>
         <target>Unrecoverable error</target>
+      </trans-unit>
+      <trans-unit id="ad7b85583eab0d11276cba0979bc97e4a45be68d" resname="gateway.error.unrecoverable_error_message_intro">
+        <jms:reference-file line="9">views/Gateway/unrecoverableError.html.twig</jms:reference-file>
+        <source>gateway.error.unrecoverable_error_message_intro</source>
+        <target state="new">gateway.error.unrecoverable_error_message_intro</target>
       </trans-unit>
       <trans-unit id="65f3ce4b0efbcaaaafd540e24188ea54d0851540" resname="gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification">
         <jms:reference-file line="29">Form/Type/CancelSecondFactorVerificationType.php</jms:reference-file>
@@ -207,7 +212,7 @@
         <target>Unprocessable login response</target>
       </trans-unit>
       <trans-unit id="1c41e8d2b8040894426471450740d39af284d440" resname="gateway.second_factor.sms.challenge_body">
-        <jms:reference-file line="286">GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
+        <jms:reference-file line="294">GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
         <source>gateway.second_factor.sms.challenge_body</source>
         <target>Your SMS code: %challenge%</target>
       </trans-unit>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2015-07-28T16:48:20Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2017-05-23T15:17:22Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -43,8 +43,8 @@
         <target>Rapporteer deze fout met bovenstaande foutcode bij SURFnet als je denkt dat deze foutmelding ongerechtvaardigd is.</target>
       </trans-unit>
       <trans-unit id="b0c6c739ae28f825ab8beb19b0ac2a2fe3318c8b" resname="gateway.error.text.your_art_code">
-        <jms:reference-file line="12">views/Exception/error.html.twig</jms:reference-file>
         <jms:reference-file line="12">views/Exception/error404.html.twig</jms:reference-file>
+        <jms:reference-file line="12">views/Exception/error.html.twig</jms:reference-file>
         <source>gateway.error.text.your_art_code</source>
         <target>De code voor deze foutmelding is</target>
       </trans-unit>
@@ -62,6 +62,11 @@
         <jms:reference-file line="7">views/Gateway/unrecoverableError.html.twig</jms:reference-file>
         <source>gateway.error.unrecoverable_error</source>
         <target>Onherstelbare fout.</target>
+      </trans-unit>
+      <trans-unit id="ad7b85583eab0d11276cba0979bc97e4a45be68d" resname="gateway.error.unrecoverable_error_message_intro">
+        <jms:reference-file line="9">views/Gateway/unrecoverableError.html.twig</jms:reference-file>
+        <source>gateway.error.unrecoverable_error_message_intro</source>
+        <target state="new">gateway.error.unrecoverable_error_message_intro</target>
       </trans-unit>
       <trans-unit id="65f3ce4b0efbcaaaafd540e24188ea54d0851540" resname="gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification">
         <jms:reference-file line="29">Form/Type/CancelSecondFactorVerificationType.php</jms:reference-file>
@@ -207,7 +212,7 @@
         <target>Onverwerkbare login-response</target>
       </trans-unit>
       <trans-unit id="1c41e8d2b8040894426471450740d39af284d440" resname="gateway.second_factor.sms.challenge_body">
-        <jms:reference-file line="286">GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
+        <jms:reference-file line="294">GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
         <source>gateway.second_factor.sms.challenge_body</source>
         <target>Je SMS-code: %challenge%</target>
       </trans-unit>

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -137,20 +137,17 @@ class GatewayController extends Controller
 
         if (!$adaptedAssertion->hasSubject()) {
             $logger->critical('Received Response without eduPersonTargetedID (EPTI)');
-            $response = $this->createResponseFailureResponse(
-                $responseContext,
-                'The "urn:mace:dir:attribute-def:eduPersonTargetedID" is not present'
-            );
-            return $this->renderSamlResponse('unprocessableResponse', $response);
+            return $this->render('unrecoverableError', [
+                'message' => 'The "urn:mace:dir:attribute-def:eduPersonTargetedID" is not present'
+            ]);
         }
 
         if (!$adaptedAssertion->hasSubjectNameId()) {
             $logger->critical('Received Response with missing NameId in eduPersonTargetedID (EPTI)');
-            $response = $this->createResponseFailureResponse(
-                $responseContext,
-                'The "urn:mace:dir:attribute-def:eduPersonTargetedID" attribute does not contain a NameID with a value.'
-            );
-            return $this->renderSamlResponse('unprocessableResponse', $response);
+
+            return $this->render('unrecoverableError', [
+                'message' => 'The "urn:mace:dir:attribute-def:eduPersonTargetedID" attribute does not contain a NameID with a value.'
+            ]);
         }
 
         $expectedInResponseTo = $responseContext->getExpectedInResponseTo();

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -136,14 +136,14 @@ class GatewayController extends Controller
         $adaptedAssertion = new AssertionAdapter($assertion);
 
         if (!$adaptedAssertion->hasSubject()) {
-            $logger->critical('Received Response without eduPersonTargetedID (EPTI)');
+            $logger->error('Received Response without eduPersonTargetedID (EPTI) attribute.');
             return $this->render('unrecoverableError', [
                 'message' => 'The "urn:mace:dir:attribute-def:eduPersonTargetedID" is not present'
             ]);
         }
 
         if (!$adaptedAssertion->hasSubjectNameId()) {
-            $logger->critical('Received Response with missing NameId in eduPersonTargetedID (EPTI)');
+            $logger->error('Received Response with missing NameId in eduPersonTargetedID (EPTI) attribute');
 
             return $this->render('unrecoverableError', [
                 'message' => 'The "urn:mace:dir:attribute-def:eduPersonTargetedID" attribute does not contain a NameID with a value.'

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -134,22 +134,6 @@ class GatewayController extends Controller
         }
 
         $adaptedAssertion = new AssertionAdapter($assertion);
-
-        if (!$adaptedAssertion->hasSubject()) {
-            $logger->error('Received Response without eduPersonTargetedID (EPTI) attribute.');
-            return $this->render('unrecoverableError', [
-                'message' => 'The "urn:mace:dir:attribute-def:eduPersonTargetedID" is not present'
-            ]);
-        }
-
-        if (!$adaptedAssertion->hasSubjectNameId()) {
-            $logger->error('Received Response with missing NameId in eduPersonTargetedID (EPTI) attribute');
-
-            return $this->render('unrecoverableError', [
-                'message' => 'The "urn:mace:dir:attribute-def:eduPersonTargetedID" attribute does not contain a NameID with a value.'
-            ]);
-        }
-
         $expectedInResponseTo = $responseContext->getExpectedInResponseTo();
         if (!$adaptedAssertion->inResponseToMatches($expectedInResponseTo)) {
             $logger->critical(sprintf(

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -340,17 +340,16 @@ class GatewayController extends Controller
 
     /**
      * @param $context
-     * @param null $message     By default the messase is null, it can be used to specify the problem with the response
      * @return SAML2_Response
      */
-    private function createResponseFailureResponse($context, $message = null)
+    private function createResponseFailureResponse($context)
     {
         /** @var \Surfnet\StepupGateway\GatewayBundle\Saml\ResponseBuilder $responseBuilder */
         $responseBuilder = $this->get('gateway.proxy.response_builder');
 
         $response = $responseBuilder
             ->createNewResponse($context)
-            ->setResponseStatus(SAML2_Const::STATUS_RESPONDER, null, $message)
+            ->setResponseStatus(SAML2_Const::STATUS_RESPONDER)
             ->get();
 
         return $response;

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/unrecoverableError.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/unrecoverableError.html.twig
@@ -6,8 +6,10 @@
     <p class="bg-danger">
         {{ 'gateway.error.unrecoverable_error'|trans }}
         {% if message is not null %}
-            <p>{{ 'gateway.error.unrecoverable_error_message_intro'|trans }}<br>
-            {{ message }}</p>
+            <br>
+            {{ 'gateway.error.unrecoverable_error_message_intro'|trans }}
+            <br>
+            {{ message }}
         {% endif %}
     </p>
 {% endblock content %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/unrecoverableError.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/unrecoverableError.html.twig
@@ -5,5 +5,9 @@
 {% block content %}
     <p class="bg-danger">
         {{ 'gateway.error.unrecoverable_error'|trans }}
+        {% if message is not null %}
+            <p>{{ 'gateway.error.unrecoverable_error_message_intro'|trans }}<br>
+            {{ message }}</p>
+        {% endif %}
     </p>
 {% endblock content %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/AssertionAdapter.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/AssertionAdapter.php
@@ -48,4 +48,20 @@ class AssertionAdapter
 
         return $subjectConfirmation->SubjectConfirmationData->InResponseTo;
     }
+
+    /**
+     * @return bool
+     */
+    public function hasSubject()
+    {
+        return !empty($this->assertion->getSubjectConfirmation());
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasSubjectNameId()
+    {
+        return !empty($this->assertion->getSubjectConfirmation()[0]->NameId);
+    }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/AssertionAdapter.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/AssertionAdapter.php
@@ -48,20 +48,4 @@ class AssertionAdapter
 
         return $subjectConfirmation->SubjectConfirmationData->InResponseTo;
     }
-
-    /**
-     * @return bool
-     */
-    public function hasSubject()
-    {
-        return !empty($this->assertion->getSubjectConfirmation());
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasSubjectNameId()
-    {
-        return !empty($this->assertion->getSubjectConfirmation()[0]->NameId);
-    }
 }


### PR DESCRIPTION
This is a pull request for the bugfix described in this issue in [pivotaltracker](https://www.pivotaltracker.com/n/projects/1163646/stories/144269753).

The `unrecoverableError.html.twig` can now display the error message. The intro that is shown above the actual error message is yet to be translated.

Also note that the error message will always be shown in English. 