### PR TITLE
Restore handling of unrecoverable errors

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/unrecoverableError.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/unrecoverableError.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <p class="bg-danger">
         {{ 'gateway.error.unrecoverable_error'|trans }}
-        {% if message is not null %}
+        {% if message is defined %}
             <br>
             {{ 'gateway.error.unrecoverable_error_message_intro'|trans }}
             <br>


### PR DESCRIPTION
Checking for 'is not null' on an undefined variable causes a template
error 'Variable does not exist'.

This bug was introduced in ec9fe64.