### PR TITLE
Log LoA resolution messages as notices

### DIFF
--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/LoaResolutionService.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/LoaResolutionService.php
@@ -72,14 +72,14 @@ final class LoaResolutionService
     public function resolve($loaId)
     {
         if (empty($loaId)) {
-            $this->logger->info('No LOA requested, sending response with status Requester Error');
+            $this->logger->notice('No LOA requested, sending response with status Requester Error');
             return '';
         }
 
         $loaId = $this->loaAliasLookup->findLoaIdByAlias($loaId);
 
         if (!$loaId) {
-            $this->logger->info(sprintf(
+            $this->logger->notice(sprintf(
                 'Requested required Loa "%s" does not have a second factor alias',
                 $loaId
             ));
@@ -87,7 +87,7 @@ final class LoaResolutionService
         }
 
         if (!$this->loaResolution->hasLoa($loaId)) {
-            $this->logger->info(sprintf(
+            $this->logger->notice(sprintf(
                 'Requested required Loa "%s" does not exist',
                 $loaId
             ));


### PR DESCRIPTION
Events logged in a happy-flow are logged with log level 'notice', so
events happening in an 'unhappy' flow should at least be a notice.