### PR TITLE
Display token selection screen in gateway

### DIFF
--- a/app/DoctrineMigrations/Version20171109102419.php
+++ b/app/DoctrineMigrations/Version20171109102419.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Surfnet\StepupGateway\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171109102419 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE second_factor DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE second_factor ADD PRIMARY KEY (id, identity_id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE second_factor DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE second_factor ADD PRIMARY KEY (id)');
+    }
+}

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-05-23T15:17:23Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2017-11-09T14:30:38Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -64,9 +64,24 @@
         <target>Unrecoverable error</target>
       </trans-unit>
       <trans-unit id="ad7b85583eab0d11276cba0979bc97e4a45be68d" resname="gateway.error.unrecoverable_error_message_intro">
-        <jms:reference-file line="9">views/Gateway/unrecoverableError.html.twig</jms:reference-file>
+        <jms:reference-file line="10">views/Gateway/unrecoverableError.html.twig</jms:reference-file>
         <source>gateway.error.unrecoverable_error_message_intro</source>
         <target state="new">gateway.error.unrecoverable_error_message_intro</target>
+      </trans-unit>
+      <trans-unit id="6d6e665338c60db3539752789daa318cc72e8002" resname="gateway.form.choose_second_factor.button.cancel">
+        <jms:reference-file line="51">Form/Type/ChooseSecondFactorType.php</jms:reference-file>
+        <source>gateway.form.choose_second_factor.button.cancel</source>
+        <target>Cancel</target>
+      </trans-unit>
+      <trans-unit id="ee2f7d95292d7dd3cae91c7855aae08d37754b5a" resname="gateway.form.choose_second_factor.button.second_factor">
+        <jms:reference-file line="36">Form/Type/ChooseSecondFactorType.php</jms:reference-file>
+        <source>gateway.form.choose_second_factor.button.second_factor</source>
+        <target>Choose</target>
+      </trans-unit>
+      <trans-unit id="712389ad04974ac705f125ab79172fc63db959f5" resname="gateway.form.choose_second_factor.button.submit">
+        <jms:reference-file line="47">Form/Type/ChooseSecondFactorType.php</jms:reference-file>
+        <source>gateway.form.choose_second_factor.button.submit</source>
+        <target>Submit</target>
       </trans-unit>
       <trans-unit id="65f3ce4b0efbcaaaafd540e24188ea54d0851540" resname="gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification">
         <jms:reference-file line="29">Form/Type/CancelSecondFactorVerificationType.php</jms:reference-file>
@@ -145,6 +160,7 @@
       </trans-unit>
       <trans-unit id="53c1b4469c10803f2e6bfb5fd31afb68c7f9556f" resname="gateway.gateway.consume_assertion.title">
         <jms:reference-file line="15">views/Gateway/consumeAssertion.html.twig</jms:reference-file>
+        <jms:reference-file line="15">views/Adfs/consumeAssertion.html.twig</jms:reference-file>
         <source>gateway.gateway.consume_assertion.title</source>
         <target>One moment please</target>
       </trans-unit>
@@ -211,8 +227,18 @@
         <source>gateway.gssp.unprocessable_response.title</source>
         <target>Unprocessable login response</target>
       </trans-unit>
+      <trans-unit id="75964b2f1748875ae1c270b8e25a9a5b2ea6b700" resname="gateway.second_factor.choose_second_factor.description">
+        <jms:reference-file line="8">views/SecondFactor/chooseSecondFactor.html.twig</jms:reference-file>
+        <source>gateway.second_factor.choose_second_factor.description</source>
+        <target>Please select your favourite token below and click the submit button.</target>
+      </trans-unit>
+      <trans-unit id="fdeeb4b0c6e2a94aec8a11728946c13a325f8366" resname="gateway.second_factor.choose_second_factor.title">
+        <jms:reference-file line="3">views/SecondFactor/chooseSecondFactor.html.twig</jms:reference-file>
+        <source>gateway.second_factor.choose_second_factor.title</source>
+        <target>Choose your favourite token</target>
+      </trans-unit>
       <trans-unit id="1c41e8d2b8040894426471450740d39af284d440" resname="gateway.second_factor.sms.challenge_body">
-        <jms:reference-file line="294">GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
+        <jms:reference-file line="332">GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
         <source>gateway.second_factor.sms.challenge_body</source>
         <target>Your SMS code: %challenge%</target>
       </trans-unit>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-05-23T15:17:22Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2017-11-09T14:30:35Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -64,9 +64,24 @@
         <target>Onherstelbare fout.</target>
       </trans-unit>
       <trans-unit id="ad7b85583eab0d11276cba0979bc97e4a45be68d" resname="gateway.error.unrecoverable_error_message_intro">
-        <jms:reference-file line="9">views/Gateway/unrecoverableError.html.twig</jms:reference-file>
+        <jms:reference-file line="10">views/Gateway/unrecoverableError.html.twig</jms:reference-file>
         <source>gateway.error.unrecoverable_error_message_intro</source>
         <target state="new">gateway.error.unrecoverable_error_message_intro</target>
+      </trans-unit>
+      <trans-unit id="6d6e665338c60db3539752789daa318cc72e8002" resname="gateway.form.choose_second_factor.button.cancel">
+        <jms:reference-file line="51">Form/Type/ChooseSecondFactorType.php</jms:reference-file>
+        <source>gateway.form.choose_second_factor.button.cancel</source>
+        <target>Annuleren</target>
+      </trans-unit>
+      <trans-unit id="ee2f7d95292d7dd3cae91c7855aae08d37754b5a" resname="gateway.form.choose_second_factor.button.second_factor">
+        <jms:reference-file line="36">Form/Type/ChooseSecondFactorType.php</jms:reference-file>
+        <source>gateway.form.choose_second_factor.button.second_factor</source>
+        <target>Kies</target>
+      </trans-unit>
+      <trans-unit id="712389ad04974ac705f125ab79172fc63db959f5" resname="gateway.form.choose_second_factor.button.submit">
+        <jms:reference-file line="47">Form/Type/ChooseSecondFactorType.php</jms:reference-file>
+        <source>gateway.form.choose_second_factor.button.submit</source>
+        <target>Volgende</target>
       </trans-unit>
       <trans-unit id="65f3ce4b0efbcaaaafd540e24188ea54d0851540" resname="gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification">
         <jms:reference-file line="29">Form/Type/CancelSecondFactorVerificationType.php</jms:reference-file>
@@ -145,6 +160,7 @@
       </trans-unit>
       <trans-unit id="53c1b4469c10803f2e6bfb5fd31afb68c7f9556f" resname="gateway.gateway.consume_assertion.title">
         <jms:reference-file line="15">views/Gateway/consumeAssertion.html.twig</jms:reference-file>
+        <jms:reference-file line="15">views/Adfs/consumeAssertion.html.twig</jms:reference-file>
         <source>gateway.gateway.consume_assertion.title</source>
         <target>Een moment geduld alsjeblieft</target>
       </trans-unit>
@@ -211,8 +227,18 @@
         <source>gateway.gssp.unprocessable_response.title</source>
         <target>Onverwerkbare login-response</target>
       </trans-unit>
+      <trans-unit id="75964b2f1748875ae1c270b8e25a9a5b2ea6b700" resname="gateway.second_factor.choose_second_factor.description">
+        <jms:reference-file line="8">views/SecondFactor/chooseSecondFactor.html.twig</jms:reference-file>
+        <source>gateway.second_factor.choose_second_factor.description</source>
+        <target>Kies een van de onderstaande tokens om door te gaan.</target>
+      </trans-unit>
+      <trans-unit id="fdeeb4b0c6e2a94aec8a11728946c13a325f8366" resname="gateway.second_factor.choose_second_factor.title">
+        <jms:reference-file line="3">views/SecondFactor/chooseSecondFactor.html.twig</jms:reference-file>
+        <source>gateway.second_factor.choose_second_factor.title</source>
+        <target>Kies uw favoriete token</target>
+      </trans-unit>
       <trans-unit id="1c41e8d2b8040894426471450740d39af284d440" resname="gateway.second_factor.sms.challenge_body">
-        <jms:reference-file line="294">GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
+        <jms:reference-file line="332">GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
         <source>gateway.second_factor.sms.challenge_body</source>
         <target>Je SMS-code: %challenge%</target>
       </trans-unit>

--- a/app/Resources/translations/validators.en_GB.xliff
+++ b/app/Resources/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2015-07-27T14:23:55Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2017-11-09T14:30:38Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/validators.nl_NL.xliff
+++ b/app/Resources/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2015-07-27T14:23:53Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2017-11-09T14:30:35Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/src/Surfnet/StepupGateway/GatewayBundle/Command/ChooseSecondFactorCommand.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Command/ChooseSecondFactorCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Command;
+
+use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor;
+
+class ChooseSecondFactorCommand
+{
+    /**
+     * @var SecondFactor[]
+     */
+    public $secondFactors;
+
+    /**
+     * @var SecondFactor
+     */
+    public $selectedSecondFactor;
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -22,14 +22,17 @@ use Psr\Log\LoggerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneCommand;
 use Surfnet\StepupBundle\Value\PhoneNumber\InternationalPhoneNumber;
+use Surfnet\StepupGateway\GatewayBundle\Command\ChooseSecondFactorCommand;
 use Surfnet\StepupGateway\GatewayBundle\Command\SendSmsChallengeCommand;
 use Surfnet\StepupGateway\GatewayBundle\Command\VerifyYubikeyOtpCommand;
+use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor;
 use Surfnet\StepupGateway\GatewayBundle\Exception\RuntimeException;
 use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
 use Surfnet\StepupGateway\U2fVerificationBundle\Value\KeyHandle;
 use Surfnet\StepupU2fBundle\Dto\SignResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
@@ -75,49 +78,94 @@ class SecondFactorController extends Controller
 
         $secondFactorCollection = $this
             ->getStepupService()
-            ->determineViableSecondFactors($context->getIdentityNameId(), $requiredLoa);
+            ->determineViableSecondFactors(
+                $context->getIdentityNameId(),
+                $requiredLoa,
+                $this->get('gateway.service.whitelist')
+            );
 
-        if (count($secondFactorCollection) === 0) {
-            $logger->notice('No second factors can give the determined Loa');
+        switch (count($secondFactorCollection)) {
+            case 0:
+                $logger->notice('No second factors can give the determined Loa');
+                return $this->forward('SurfnetStepupGatewayGatewayBundle:Gateway:sendLoaCannotBeGiven');
+                break;
 
-            return $this->forward('SurfnetStepupGatewayGatewayBundle:Gateway:sendLoaCannotBeGiven');
+            case 1:
+                $secondFactor = $secondFactorCollection->first();
+                $logger->notice(sprintf(
+                    'Found "%d" second factors, using second factor of type "%s"',
+                    count($secondFactorCollection),
+                    $secondFactor->secondFactorType
+                ));
+
+                return $this->selectAndRedirectTo($secondFactor, $context);
+                break;
+
+            default:
+                return $this->forward(
+                    'SurfnetStepupGatewayGatewayBundle:SecondFactor:chooseSecondFactor',
+                    ['secondFactors' => $secondFactorCollection]
+                );
+                break;
+        }
+    }
+
+    /**
+     * @Template
+     * @param Request $request
+     * @return array|RedirectResponse|Response
+     */
+    public function chooseSecondFactorAction(Request $request)
+    {
+        $context = $this->getResponseContext();
+        $originalRequestId = $context->getInResponseTo();
+
+        $requiredLoa = $this
+            ->getStepupService()
+            ->resolveHighestRequiredLoa(
+                $context->getRequiredLoa(),
+                $context->getIdentityNameId(),
+                $context->getServiceProvider()
+            );
+
+        $secondFactors = $this
+            ->getStepupService()
+            ->determineViableSecondFactors(
+                $context->getIdentityNameId(),
+                $requiredLoa,
+                $this->get('gateway.service.whitelist')
+            );
+
+        $command = new ChooseSecondFactorCommand();
+        $command->secondFactors = $secondFactors;
+
+        $logger = $this->get('surfnet_saml.logger')->forAuthentication($originalRequestId);
+
+        $form = $this
+            ->createForm(
+                'gateway_choose_second_factor',
+                $command,
+                ['action' => $this->generateUrl('gateway_verify_second_factor_choose_second_factor')]
+            )
+            ->handleRequest($request);
+
+        if ($form->get('cancel')->isClicked()) {
+            return $this->forward('SurfnetStepupGatewayGatewayBundle:Gateway:sendAuthenticationCancelledByUser');
         }
 
-        // will be replaced by a second factor selection screen once we support multiple
-        /** @var \Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor $secondFactor */
-        $secondFactor = $secondFactorCollection->first();
-        // when multiple second factors are supported this should be moved into the
-        // StepUpAuthenticationService::determineViableSecondFactors and handled in a performant way
-        // currently keeping this here for visibility
-        if (!$this->get('gateway.service.whitelist')->contains($secondFactor->institution)) {
+        if ($form->isSubmitted() && $form->isValid()) {
+            $secondFactorIndex = $command->selectedSecondFactor;
+            $secondFactor = $secondFactors->get($secondFactorIndex);
             $logger->notice(sprintf(
-                'Second factor "%s" is listed for institution "%s" which is not on the whitelist, sending Loa '
-                . 'cannot be given response',
-                $secondFactor->secondFactorId,
-                $secondFactor->institution
+                'User chose "%s" to use as second factor',
+                $secondFactor->secondFactorType
             ));
 
-            return $this->forward('SurfnetStepupGatewayGatewayBundle:Gateway:sendLoaCannotBeGiven');
+            // Forward to action to verify possession of second factor
+            return $this->selectAndRedirectTo($secondFactor, $context);
         }
 
-        $logger->notice(sprintf(
-            'Found "%d" second factors, using second factor of type "%s"',
-            count($secondFactorCollection),
-            $secondFactor->secondFactorType
-        ));
-
-        $context->saveSelectedSecondFactor($secondFactor);
-
-        $this->getStepupService()->clearSmsVerificationState();
-
-        $route = 'gateway_verify_second_factor_';
-        if ($secondFactor->isGssf()) {
-            $route .= 'gssf';
-        } else {
-            $route .= strtolower($secondFactor->secondFactorType);
-        }
-
-        return $this->redirect($this->generateUrl($route));
+        return ['form' => $form->createView()];
     }
 
     public function verifyGssfAction()
@@ -523,5 +571,21 @@ class SecondFactorController extends Controller
         }
 
         return $selectedSecondFactor;
+    }
+
+    private function selectAndRedirectTo(SecondFactor $secondFactor, ResponseContext $context)
+    {
+        $context->saveSelectedSecondFactor($secondFactor);
+
+        $this->getStepupService()->clearSmsVerificationState();
+
+        $route = 'gateway_verify_second_factor_';
+        if ($secondFactor->isGssf()) {
+            $route .= 'gssf';
+        } else {
+            $route .= strtolower($secondFactor->secondFactorType);
+        }
+
+        return $this->redirect($this->generateUrl($route));
     }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/SecondFactor.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/SecondFactor.php
@@ -25,10 +25,23 @@ use Surfnet\StepupBundle\Value\SecondFactorType;
 
 /**
  * @ORM\Entity(repositoryClass="Surfnet\StepupGateway\GatewayBundle\Entity\DoctrineSecondFactorRepository")
- * @ORM\Table
+ * @ORM\Table(
+ *      indexes={
+ *          @ORM\Index(name="idx_secondfactor_nameid", columns={"name_id"}),
+ *      }
+ * )
+ * @SuppressWarnings(PHPMD.UnusedPrivateFields)
  */
 class SecondFactor
 {
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(length=36)
+     */
+    private $id;
+
     /**
      * @var string
      *

--- a/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/ChooseSecondFactorType.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/ChooseSecondFactorType.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Form\Type;
+
+use Surfnet\StepupGateway\GatewayBundle\Command\ChooseSecondFactorCommand;
+use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ChooseSecondFactorType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        /** @var ChooseSecondFactorCommand $data */
+        $data = $builder->getData();
+        $secondFactors = array_values($data->secondFactors->getValues());
+
+        $builder->add('selectedSecondFactor', 'choice', [
+            'label' => 'gateway.form.choose_second_factor.button.second_factor',
+            'expanded' => true,
+            'multiple' => false,
+            'choices' => $secondFactors,
+            'choice_label' => function ($index) use ($secondFactors) {
+                /** @var SecondFactor[] $secondFactors */
+                return ucfirst($secondFactors[$index]->secondFactorType);
+            }
+        ]);
+
+        $builder->add('choose', 'submit', [
+            'label' => 'gateway.form.choose_second_factor.button.submit',
+            'attr' => [ 'class' => 'btn btn-primary pull-right' ],
+        ]);
+        $builder->add('cancel', 'submit', [
+            'label' => 'gateway.form.choose_second_factor.button.cancel',
+            'attr'  => ['class' => 'btn btn-danger', 'formnovalidate' => 'formnovalidate'],
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => 'Surfnet\StepupGateway\GatewayBundle\Command\ChooseSecondFactorCommand',
+        ]);
+    }
+
+    public function getName()
+    {
+        return 'gateway_choose_second_factor';
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/routing.yml
@@ -52,3 +52,8 @@ gateway_verify_second_factor_u2f_cancel_authentication:
     path:     /verify-second-factor/u2f/cancel
     methods:  [POST]
     defaults: { _controller: SurfnetStepupGatewayGatewayBundle:SecondFactor:cancelU2fAuthentication }
+
+gateway_verify_second_factor_choose_second_factor:
+    path:     /choose-second-factor
+    methods:  [GET, POST]
+    defaults: { _controller: SurfnetStepupGatewayGatewayBundle:SecondFactor:chooseSecondFactor }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
@@ -117,6 +117,10 @@ services:
         class: Surfnet\StepupGateway\GatewayBundle\Form\Type\VerifyYubikeyOtpType
         tags: [{ name: form.type, alias: gateway_verify_yubikey_otp }]
 
+    gateway.form.choose_second_factor:
+        class: Surfnet\StepupGateway\GatewayBundle\Form\Type\ChooseSecondFactorType
+        tags: [{ name: form.type, alias: gateway_choose_second_factor }]
+
     gateway.form.send_sms_challenge:
         class: Surfnet\StepupGateway\GatewayBundle\Form\Type\SendSmsChallengeType
         tags: [{ name: form.type, alias: gateway_send_sms_challenge }]

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/chooseSecondFactor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/chooseSecondFactor.html.twig
@@ -1,0 +1,12 @@
+{% extends "::base.html.twig" %}
+
+{% block page_title %}{{ 'gateway.second_factor.choose_second_factor.title'|trans }}{% endblock %}
+
+{% block content %}
+    <h2>{{ block('page_title') }}</h2>
+
+    <p>{{ 'gateway.second_factor.choose_second_factor.description'|trans }}</p>
+
+    {{ form(form) }}
+
+{% endblock %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/StepUpAuthenticationService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/StepUpAuthenticationService.php
@@ -116,13 +116,15 @@ class StepUpAuthenticationService
     }
 
     /**
-     * @param string          $identityNameId
-     * @param Loa             $requiredLoa
+     * @param string $identityNameId
+     * @param Loa $requiredLoa
+     * @param WhitelistService $whitelistService
      * @return \Doctrine\Common\Collections\Collection
      */
     public function determineViableSecondFactors(
         $identityNameId,
-        Loa $requiredLoa
+        Loa $requiredLoa,
+        WhitelistService $whitelistService
     ) {
 
         $candidateSecondFactors = $this->secondFactorRepository->getAllMatchingFor(
@@ -133,6 +135,24 @@ class StepUpAuthenticationService
         $this->logger->info(
             sprintf('Loaded %d matching candidate second factors', count($candidateSecondFactors))
         );
+
+        foreach ($candidateSecondFactors as $key => $secondFactor) {
+            if (!$whitelistService->contains($secondFactor->institution)) {
+                $this->logger->notice(
+                    sprintf(
+                        'Second factor "%s" is listed for institution "%s" which is not on the whitelist',
+                        $secondFactor->secondFactorId,
+                        $secondFactor->institution
+                    )
+                );
+
+                $candidateSecondFactors->remove($key);
+            }
+        }
+
+        if ($candidateSecondFactors->isEmpty()) {
+            $this->logger->alert('No suitable candidate second factors found, sending Loa cannot be given response');
+        }
 
         return $candidateSecondFactors;
     }
@@ -159,7 +179,11 @@ class StepUpAuthenticationService
         }
 
         $spConfiguredLoas = $serviceProvider->get('configuredLoas');
-        $loaCandidates->add($spConfiguredLoas['__default__']);
+
+        if (!$loaCandidates->contains($spConfiguredLoas['__default__'])) {
+            $loaCandidates->add($spConfiguredLoas['__default__']);
+        }
+
         $this->logger->info(sprintf('Added SP\'s default Loa "%s" as candidate', $spConfiguredLoas['__default__']));
 
         $institutions = $this->determineInstitutionsByIdentityNameId($identityNameId);


### PR DESCRIPTION
**Review notes**
When a user has more than one registred tokens that meet the required LOA, the Gateway will allow the user to select its favourite token.

Note that there was a change to the SecondFactor entity. This changes was made in Middleware but not yet 'synced' to the gateway entity definition. This caused strange query results.

**Tasks**
 - [x] Travis build is passing
 - [x] Updated documentation
 - [x] Updated pivotal tracker
 - [x] Wrote appropriate tests

This PR is part of a series of changes in [SS](https://github.com/OpenConext/Stepup-SelfService/pull/127), [MW](https://github.com/OpenConext/Stepup-Middleware/pull/199) and [GW](https://github.com/OpenConext/Stepup-Gateway/pull/123).

For more information about the changes see [Pivotal](https://www.pivotaltracker.com/story/show/144697285) and the updated [docs](https://github.com/OpenConext/Stepup-Deploy/wiki/API-Design).