### PR TITLE
Handle impossible SF action more graceful

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Exception/LoaCannotBeGivenException.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Exception/LoaCannotBeGivenException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Exception;
+
+class LoaCannotBeGivenException extends DomainException
+{
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/StepUpAuthenticationService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/StepUpAuthenticationService.php
@@ -38,6 +38,7 @@ use Surfnet\StepupGateway\GatewayBundle\Command\SendSmsChallengeCommand;
 use Surfnet\StepupGateway\GatewayBundle\Command\VerifyYubikeyOtpCommand;
 use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor;
 use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactorRepository;
+use Surfnet\StepupGateway\GatewayBundle\Exception\LoaCannotBeGivenException;
 use Surfnet\StepupGateway\GatewayBundle\Exception\RuntimeException;
 use Surfnet\StepupGateway\GatewayBundle\Service\StepUp\YubikeyOtpVerificationResult;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -407,13 +408,13 @@ class StepUpAuthenticationService
 
         // Validations are performed on the institutions
         if (empty($institutions) && array_key_exists($identityInstitution, $spConfiguredLoas)) {
-            throw new RuntimeException(
+            throw new LoaCannotBeGivenException(
                 'The authenticating user cannot provide a token for the institution it is authenticating for.'
             );
         }
 
         if (empty($institutions)) {
-            throw new RuntimeException(
+            throw new LoaCannotBeGivenException(
                 'The authenticating user does not have any vetted tokens.'
             );
         }
@@ -427,7 +428,7 @@ class StepUpAuthenticationService
             );
 
             if (empty($institutionMatches)) {
-                throw new RuntimeException(
+                throw new LoaCannotBeGivenException(
                     'None of the authenticating users tokens are registered at an institution the user is currently ' .
                     'authenticating from.'
                 );

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/StepUpAuthenticationServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/StepUpAuthenticationServiceTest.php
@@ -28,6 +28,7 @@ use Surfnet\StepupBundle\Service\SmsSecondFactorService;
 use Surfnet\StepupBundle\Value\Loa;
 use Surfnet\StepupGateway\ApiBundle\Service\YubikeyService;
 use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactorRepository;
+use Surfnet\StepupGateway\GatewayBundle\Exception\LoaCannotBeGivenException;
 use Surfnet\StepupGateway\GatewayBundle\Exception\RuntimeException;
 use Surfnet\StepupGateway\GatewayBundle\Service\InstitutionMatchingHelper;
 use Surfnet\StepupGateway\GatewayBundle\Service\StepUpAuthenticationService;
@@ -262,7 +263,7 @@ final class StepUpAuthenticationServiceTest extends PHPUnit_Framework_TestCase
      * Loa configuration
      *
      * @dataProvider configuredLoas
-     * @expectedException \Surfnet\StepupGateway\GatewayBundle\Exception\RuntimeException
+     * @expectedException \Surfnet\StepupGateway\GatewayBundle\Exception\LoaCannotBeGivenException
      * @expectedExceptionMessage None of the authenticating users tokens are registered at an institution the user is
      *                           currently authenticating from.
      */
@@ -456,7 +457,9 @@ final class StepUpAuthenticationServiceTest extends PHPUnit_Framework_TestCase
             );
             $this->assertEquals($expectedOutcome, (string) $loa, sprintf('Unexpected outcome in test: %d', $index));
         } catch (RuntimeException $e) {
-            $this->assertEquals($expectedOutcome, $e->getMessage(), sprintf('Unexpected outcome in test: %d', $index));
+            $this->assertEquals($expectedOutcome, $e->getMessage(), sprintf('Unexpected RuntimeException in test: %d', $index));
+        } catch (LoaCannotBeGivenException $e) {
+            $this->assertEquals($expectedOutcome, $e->getMessage(), sprintf('Unexpected LoaCannotBeGivenException in test: %d', $index));
         }
     }
 


### PR DESCRIPTION
When the authenticating user cannot provide a sufficient token either
because it was vetted at the wrong institution or the user did not
have any tokens at all. The controller wil now forward these occurences
to the sendLoaCannotBeGiven action of the gateway controller. This
prevents the display of a generic error page. But shows the end user
with the message: 'You are not authorised to log in.'

To achieve this, domain exceptions are thrown instead of the more severe
runtime exceptions. The domain exception is caught in the SF controller
and forwards the authenticating user to the correct endpoint.

Test expectancies have been updated to the correct exception types.