### PR TITLE
Add prematurely removed findAllByIdentityNameId

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/DoctrineSecondFactorRepository.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/DoctrineSecondFactorRepository.php
@@ -73,4 +73,18 @@ class DoctrineSecondFactorRepository extends EntityRepository implements SecondF
         }
         return '';
     }
+
+    /**
+     * @param $identityNameId
+     * @return \Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor[]
+     */
+    private function findAllByIdentityNameId($identityNameId)
+    {
+        /** @var \Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor[] $secondFactors */
+        return $this->createQueryBuilder('sf')
+            ->where('sf.nameId = :nameId')
+            ->setParameter('nameId', $identityNameId)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/StepUpAuthenticationServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/StepUpAuthenticationServiceTest.php
@@ -365,10 +365,6 @@ final class StepUpAuthenticationServiceTest extends PHPUnit_Framework_TestCase
 
         $this->logger->shouldReceive('info');
 
-        $this->secondFactorRepository
-            ->shouldReceive('getAllInstitutions')
-            ->andReturn($institutionsBasedOnVettedTokens);
-
         try {
             $loa = $this->service->resolveHighestRequiredLoa(
                 $spRequestedLoa,


### PR DESCRIPTION
The 'findAllByIdentityNameId' was not only used by the previous
'getAllInstitutionsByNameId' method, but also used by
'getAllMatchingFor'.

Boyscout: removed a mockery assumption that was no longer relevant.