### PR TITLE
Allow mixed-case schacHomeOrganization values

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -58,19 +58,17 @@ class SecondFactorController extends Controller
             // Retrieve all requirements to determine the required LoA
             $requestedLoa = $context->getRequiredLoa();
             $spConfiguredLoas = $context->getServiceProvider()->get('configuredLoas');
-            $idpSho = $context->getSchacHomeOrganization();
-            $userSho = $this->getStepupService()->getUserShoByIdentityNameId($context->getIdentityNameId());
 
-            $this->getStepupService()->assertValidShoFormat($idpSho);
-            $this->getStepupService()->assertValidShoFormat($userSho);
+            $normalizedIdpSho = $context->getNormalizedSchacHomeOrganization();
+            $normalizedUserSho = $this->getStepupService()->getNormalizedUserShoByIdentityNameId($context->getIdentityNameId());
 
             $requiredLoa = $this
                 ->getStepupService()
                 ->resolveHighestRequiredLoa(
                     $requestedLoa,
                     $spConfiguredLoas,
-                    $idpSho,
-                    $userSho
+                    $normalizedIdpSho,
+                    $normalizedUserSho
                 );
         } catch (LoaCannotBeGivenException $e) {
             // Log the message of the domain exception, this contains a meaningful message.

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
@@ -202,9 +202,22 @@ class ResponseContext
         return $this->stateHandler->getIdentityNameId();
     }
 
-    public function getSchacHomeOrganization()
+    /**
+     * Return the lower-cased schacHomeOrganization value from the assertion.
+     *
+     * Comparisons on SHO values should always be case insensitive. Stepup
+     * configuration always contains SHO values lower-cased, so this getter
+     * can be used to compare the SHO with configured values.
+     *
+     * @see StepUpAuthenticationService::resolveHighestRequiredLoa()
+     *
+     * @return null|string
+     */
+    public function getNormalizedSchacHomeOrganization()
     {
-        return $this->stateHandler->getSchacHomeOrganization();
+        return strtolower(
+            $this->stateHandler->getSchacHomeOrganization()
+        );
     }
 
     /**

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/StepUpAuthenticationServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/StepUpAuthenticationServiceTest.php
@@ -479,36 +479,4 @@ final class StepUpAuthenticationServiceTest extends PHPUnit_Framework_TestCase
         return $combinations;
     }
 
-    public function test_assert_valid_sho()
-    {
-        $result = $this->service->assertValidShoFormat('valid.sho');
-        $this->assertNull($result);
-
-        $result = $this->service->assertValidShoFormat('');
-        $this->assertNull($result);
-    }
-
-    /**
-     * @dataProvider invalidShoProvider
-     * @param $invalidSho
-     */
-    public function test_assert_invalid_sho($invalidSho)
-    {
-        $this->setExpectedException(
-            InvalidStepupShoFormatException::class,
-            sprintf('Encountered an invalid schacHomeOrganization value "%s".', $invalidSho)
-        );
-        $this->service->assertValidShoFormat($invalidSho);
-    }
-
-    public function invalidShoProvider()
-    {
-        return [
-            ['INVALID'],
-            ['iNvAlId'],
-            ['iNvÄlId'],
-            ['in.valiD'],
-        ];
-    }
-
 }


### PR DESCRIPTION
Commit 94080f2 introduced behaviour to the gateway were an error was
thrown on mixed-case SHO values. This behaviour is reverted in this
commit: mixed-case SHO is allowed and compared in an case-insensitive
manner.

While the case of SHO values of the SP/IDP no longer matters for
StepUp, it is important for the SP configuration (SP-configured LoAs)
to always have lower-cased SHOs.