### PR TITLE
Fix notice to specicy requested LoA.

### DIFF
--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/LoaResolutionService.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/LoaResolutionService.php
@@ -76,9 +76,9 @@ final class LoaResolutionService
             return '';
         }
 
-        $loaId = $this->loaAliasLookup->findLoaIdByAlias($loaId);
+        $derefLoaId = $this->loaAliasLookup->findLoaIdByAlias($loaId);
 
-        if (!$loaId) {
+        if (!$derefLoaId) {
             $this->logger->notice(sprintf(
                 'Requested required Loa "%s" does not have a second factor alias',
                 $loaId
@@ -86,14 +86,14 @@ final class LoaResolutionService
             return '';
         }
 
-        if (!$this->loaResolution->hasLoa($loaId)) {
+        if (!$this->loaResolution->hasLoa($derefLoaId)) {
             $this->logger->notice(sprintf(
                 'Requested required Loa "%s" does not exist',
-                $loaId
+                $derefLoaId
             ));
             return '';
         }
 
-        return $loaId;
+        return $derefLoaId;
     }
 }


### PR DESCRIPTION
The notice is only triggered when $loaId is false, therefore will
always log "" as the requested LoA and the interpolation is useless.
Fix this by not overwriting $loaId on dereference.