### PR TITLE
Don't clear state on SAML responses or error pages

### DIFF
--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
@@ -295,9 +295,6 @@ class SamlProxyController extends Controller
             'relayState' => $stateHandler->getRelayState()
         ]);
 
-        // clear the state so we can call again :)
-        $stateHandler->clear();
-
         return $response;
     }
 


### PR DESCRIPTION
When Stepup renders a SAML response or error page, the state of the
request is never reset. If for whatever reason the request to the
consume-assertion request happens twice, both requests succeed. Also,
if the user refreshes the error page, the exact same error
occurs. This is intended behaviour and a good thing.

When Stepup acts as a proxy for GSSP, the behaviour is different. The
state is cleared after consume-assertion and when rendering an error
page. When the error page is refreshed by the user, different errors
are triggered because the request does not match the state. For
example, this error might be logged when refreshing an error page:

    Invalid Argument, parameter "requestId" should be of type "string", "NULL" given

This commit changes the proxy controllers to never reset the state
when a request is handled. The behaviour in Stepup is now consistent.