### PR TITLE
Clear previous authentication state when proxying GSSP requests

### DIFF
--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
@@ -90,6 +90,12 @@ class SamlProxyController extends Controller
 
         /** @var StateHandler $stateHandler */
         $stateHandler = $provider->getStateHandler();
+
+        // Clear the state of the previous SSO action. Request data of
+        // previous SSO actions should not have any effect in subsequent SSO
+        // actions.
+        $stateHandler->clear();
+
         $stateHandler
             ->setRequestId($originalRequestId)
             ->setRequestServiceProvider($originalRequest->getServiceProvider())


### PR DESCRIPTION
This PR is intended to be merged for release 14.

When stepup acts as a proxy for a GSSP authentication or registration
action, state from previous authentication requests was not properly
cleared. This caused two bugs:

1. Requested Subject NameID "%s" and Response NameID "%s" do not match

A GSSP registration request does not contain a NameID. Instead of
handling the request without NameID, the NameID of the previous
authentication request was used resulting in above error.

2. Unknown Generic SAML Stepup Provider requested "%s", known providers...

When handling a GSSP registration request, the flag
"secondFactorVerificationRequested" set by the previous authentication
action was not reset, causing above error when handling an error in
the GSSP request (for example, when bug 1. was triggered).

This commit explicitly clears the state when the single-sign-on action
is started.

Other parts of Stepup (regular SSO, SFO) are not vulnerable to this
bug because they always set the complete state in one swoop.

See: https://www.pivotaltracker.com/story/show/155774630