### PR TITLE
Clear previous authentication state on normal SSO and SFO requests

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -61,6 +61,11 @@ class GatewayController extends Controller
 
         /** @var \Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler $stateHandler */
         $stateHandler = $this->get('gateway.proxy.state_handler');
+
+        // Clear the state of the previous SSO action. Request data of previous
+        // SSO actions should not have any effect in subsequent SSO actions.
+        $stateHandler->clear();
+
         $stateHandler
             ->setRequestId($originalRequestId)
             ->setRequestServiceProvider($originalRequest->getServiceProvider())

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/Proxy/ProxyStateHandler.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/Proxy/ProxyStateHandler.php
@@ -38,6 +38,20 @@ class ProxyStateHandler
     }
 
     /**
+     * Clear the complete state, leaving other states intact.
+     */
+    public function clear()
+    {
+        $all = $this->session->all();
+
+        foreach (array_keys($all) as $key) {
+            if (strpos($key, self::SESSION_PATH) === 0) {
+                $this->session->remove($key);
+            }
+        }
+    }
+
+    /**
      * @param string $originalRequestId
      * @return $this
      */

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
@@ -85,6 +85,11 @@ class SecondFactorOnlyController extends Controller
         }
 
         $stateHandler = $this->get('gateway.proxy.state_handler');
+
+        // Clear the state of the previous SSO action. Request data of previous
+        // SSO actions should not have any effect in subsequent SSO actions.
+        $stateHandler->clear();
+
         $stateHandler
             ->setRequestId($originalRequestId)
             ->setRequestServiceProvider($originalRequest->getServiceProvider())


### PR DESCRIPTION
This is a defense-in-depth improvement and will NOT be part of release-14.

The problem where states were mixed up when handling GSSP requests was
resolved by explicitly clearing the state on every new SSO
request. This was resolved in PR #138.

The problem does not exist on normal SSO/SFO requests, but the session
state can in theory still be inconsistent in those cases. It's also
prone to errors on future changes.

This commit streamlines the way state is cleared: when state is stored
when a GSSP SSO, SSO or SFO initiated, the state is first always
cleared to prevent the possibility of previous state being available
in the new SSO request.

See: https://www.pivotaltracker.com/story/show/155774630