### PR TITLE
Fix broken WAYG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ branches:
   only:
     - master
     - develop
+    - release/2.8


### PR DESCRIPTION
The chooseSecondFactorAction was not updated, following the update to it's related
 selectSecondFactorForVerificationAction. Resulting in incorrect Loa
 determination and a fatal error on a missing/renamed
 getSchacHomeOrganization method call.

The solution was to update the action to match the logic used in the
 selectSecondFactorForVerificationAction. As both actions need to
 determine which Loa is required.

An extra log message was added to follow the logging style already in
 use more closely.

Pivotal: https://www.pivotaltracker.com/story/show/156006702