### PR TITLE
Authentication screens restyle

### DIFF
--- a/app/Resources/public/less/authentication.less
+++ b/app/Resources/public/less/authentication.less
@@ -10,11 +10,11 @@ body.authentication {
   }
 
   .container.authentication {
-    max-width: 75rem;
-    margin-top: 2rem;
     background: #fff;
     border-radius: 4px;
     box-shadow: 0 1px 4px rgba(0, 0, 0, .2);
+    margin-top: 2rem;
+    max-width: 75rem;
     padding: 0 2rem;
   }
   .page-header {
@@ -31,14 +31,14 @@ body.authentication {
   }
 
   form[name="gateway_verify_yubikey_otp"] {
-    padding: 2rem 0 4rem 0;
     max-width: 525px;
+    padding: 2rem 0 4rem 0;
   }
 
   div.form-gateway-send-sms-challenge {
     margin: 1em auto;
-    padding: 0.75em 1em;
     max-width: 525px;
+    padding: 0.75em 1em;
 
     form {
       text-align: center;
@@ -52,11 +52,11 @@ body.authentication {
   form[name="gateway_verify_sms_challenge"] {
     padding: 0 2em 0 0;
     input[type="text"] {
-      font-family: "Monaco", "Inconsolata", "Consolas", monospace;
-      text-transform: uppercase;
-      max-width: 20rem;
-      margin: 1rem 1rem 1rem 0;
       display: inline-block;
+      font-family: "Monaco", "Inconsolata", "Consolas", monospace;
+      margin: 1rem 1rem 1rem 0;
+      max-width: 20rem;
+      text-transform: uppercase;
 
       &::placeholder {
         text-transform: none;

--- a/app/Resources/public/less/authentication.less
+++ b/app/Resources/public/less/authentication.less
@@ -31,8 +31,7 @@ body.authentication {
   }
 
   form[name="gateway_verify_yubikey_otp"] {
-    margin: 1em auto;
-    padding: 0.75em 1em;
+    padding: 2rem 0 4rem 0;
     max-width: 525px;
   }
 

--- a/app/Resources/public/less/authentication.less
+++ b/app/Resources/public/less/authentication.less
@@ -1,0 +1,73 @@
+
+body.authentication {
+  background-color: @gray-lighter;
+  font-size: 15px;
+  line-height: 20px;
+
+  h1 {
+    font-size: 24px;
+    line-height: 26px;
+  }
+
+  .container.authentication {
+    max-width: 75rem;
+    margin-top: 2rem;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, .2);
+    padding: 0 2rem;
+  }
+  .page-header {
+    margin: 0;
+    padding: 2rem 0 1rem 0;
+  }
+
+  .authentication-content {
+    padding: 4rem;
+  }
+
+  footer {
+    padding-bottom: 2rem;
+  }
+
+  form[name="gateway_verify_yubikey_otp"] {
+    margin: 1em auto;
+    padding: 0.75em 1em;
+    max-width: 525px;
+  }
+
+  div.form-gateway-send-sms-challenge {
+    margin: 1em auto;
+    padding: 0.75em 1em;
+    max-width: 525px;
+
+    form {
+      text-align: center;
+    }
+  }
+
+  div.form-gateway-verify-sms-challenge div.row {
+    margin: 2rem 0 3rem 0;
+  }
+
+  form[name="gateway_verify_sms_challenge"] {
+    padding: 0 2em 0 0;
+    input[type="text"] {
+      font-family: "Monaco", "Inconsolata", "Consolas", monospace;
+      text-transform: uppercase;
+      max-width: 20rem;
+      margin: 1rem 1rem 1rem 0;
+      display: inline-block;
+    }
+    button {
+      display: inline-block;
+    }
+    .btn-link{
+      padding-left: 0;
+    }
+  }
+
+  form[name="gateway_cancel_second_factor_verification"] {
+    text-align: center;
+  }
+}

--- a/app/Resources/public/less/authentication.less
+++ b/app/Resources/public/less/authentication.less
@@ -11,11 +11,14 @@ body.authentication {
 
   .container.authentication {
     background: #fff;
-    border-radius: 4px;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, .2);
-    margin-top: 2rem;
-    max-width: 75rem;
     padding: 0 2rem;
+
+    @media (min-width: @medium) {
+      border-radius: 4px;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, .2);
+      margin-top: 2rem;
+      max-width: 75rem;
+    }
   }
   .page-header {
     margin: 0;
@@ -24,6 +27,10 @@ body.authentication {
 
   .authentication-content {
     padding: 4rem;
+
+    @media (max-width: @small) {
+      padding: 2rem 0;
+    }
   }
 
   footer {

--- a/app/Resources/public/less/authentication.less
+++ b/app/Resources/public/less/authentication.less
@@ -58,11 +58,15 @@ body.authentication {
       max-width: 20rem;
       margin: 1rem 1rem 1rem 0;
       display: inline-block;
+
+      &::placeholder {
+        text-transform: none;
+      }
     }
     button {
       display: inline-block;
     }
-    .btn-link{
+    .btn-link {
       padding-left: 0;
     }
   }

--- a/app/Resources/public/less/authentication.less
+++ b/app/Resources/public/less/authentication.less
@@ -35,6 +35,14 @@ body.authentication {
 
   footer {
     padding-bottom: 2rem;
+
+    form {
+      display: inline;
+
+      button {
+        padding: 0;
+      }
+    }
   }
 
   form[name="gateway_verify_yubikey_otp"] {

--- a/app/Resources/public/less/default.less
+++ b/app/Resources/public/less/default.less
@@ -2,7 +2,7 @@
 @FontAwesomePath: "/fonts";
 @fa-font-path: "/fonts";
 
-`div.page-header {
+div.page-header {
     img.logo {
         max-width: 180px;
         max-height: 90px;

--- a/app/Resources/public/less/default.less
+++ b/app/Resources/public/less/default.less
@@ -2,41 +2,10 @@
 @FontAwesomePath: "/fonts";
 @fa-font-path: "/fonts";
 
-div.page-header {
+`div.page-header {
     img.logo {
         max-width: 180px;
         max-height: 90px;
-    }
-}
-
-form[name="gateway_verify_yubikey_otp"] {
-    margin: 1em auto;
-    padding: 0.75em 1em;
-    max-width: 525px;
-}
-
-div.form-gateway-send-sms-challenge {
-    margin: 1em auto;
-    padding: 0.75em 1em;
-    max-width: 525px;
-
-    form {
-        text-align: center;
-    }
-}
-
-form[name="gateway_verify_sms_challenge"] {
-    margin: 1em auto;
-    padding: 0.75em 1em;
-    max-width: 525px;
-
-    input[type="text"] {
-        font-family: "Monaco", "Inconsolata", "Consolas", monospace;
-        text-transform: uppercase;
-    }
-
-    a.btn-default {
-        margin-right: 15px;
     }
 }
 
@@ -45,9 +14,6 @@ form[name="gateway_verify_sms_challenge"] {
     left: 100%;
 }
 
-form[name="gateway_cancel_second_factor_verification"] {
-    text-align: center;
-}
 
 div.middle {
     display: flex;

--- a/app/Resources/public/less/footer.less
+++ b/app/Resources/public/less/footer.less
@@ -1,0 +1,8 @@
+footer .containing-cancel button.nav-link {
+    // The button component extends the behaviour of a navigation anchor
+    &:extend(.nav > li > a);
+    &:hover {
+        &:extend(.nav > li > a:hover);
+    }
+    padding: 9px 12px;
+}

--- a/app/Resources/public/less/footer.less
+++ b/app/Resources/public/less/footer.less
@@ -1,8 +1,0 @@
-footer .containing-cancel button.nav-link {
-    // The button component extends the behaviour of a navigation anchor
-    &:extend(.nav > li > a);
-    &:hover {
-        &:extend(.nav > li > a:hover);
-    }
-    padding: 9px 12px;
-}

--- a/app/Resources/public/less/style.less
+++ b/app/Resources/public/less/style.less
@@ -1,4 +1,5 @@
 @import "../../../../vendor/mopa/bootstrap-bundle/Mopa/Bundle/BootstrapBundle/Resources/public/less/bootstrap-fontawesome4.less";
 @import "default.less";
 @import "footer.less";
+@import "authentication.less";
 @import "wayg.less";

--- a/app/Resources/public/less/style.less
+++ b/app/Resources/public/less/style.less
@@ -2,6 +2,5 @@
 
 @import "vars.less";
 @import "default.less";
-@import "footer.less";
 @import "authentication.less";
 @import "wayg.less";

--- a/app/Resources/public/less/style.less
+++ b/app/Resources/public/less/style.less
@@ -1,3 +1,4 @@
 @import "../../../../vendor/mopa/bootstrap-bundle/Mopa/Bundle/BootstrapBundle/Resources/public/less/bootstrap-fontawesome4.less";
 @import "default.less";
+@import "footer.less";
 @import "wayg.less";

--- a/app/Resources/public/less/style.less
+++ b/app/Resources/public/less/style.less
@@ -1,4 +1,6 @@
 @import "../../../../vendor/mopa/bootstrap-bundle/Mopa/Bundle/BootstrapBundle/Resources/public/less/bootstrap-fontawesome4.less";
+
+@import "vars.less";
 @import "default.less";
 @import "footer.less";
 @import "authentication.less";

--- a/app/Resources/public/less/vars.less
+++ b/app/Resources/public/less/vars.less
@@ -1,0 +1,4 @@
+// Screen sizes, as defined in OpenConext-engineblock
+@small: 400px;
+@medium: 800px;
+@large: 1200px;

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-23T09:48:49Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-03-27T11:03:27Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -22,6 +22,11 @@
         <target>Login response could not be processed.</target>
         <jms:reference-file line="7">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/unprocessableResponse.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="7ae5055bfdf6e6100256f6148115dfaa4b06ac52" resname="gateway.form.cancel_authentication.button.cancel">
+        <source>gateway.form.cancel_authentication.button.cancel</source>
+        <target>Cancel</target>
+        <jms:reference-file line="30">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/CancelAuthenticationType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="65f3ce4b0efbcaaaafd540e24188ea54d0851540" resname="gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification">
         <source>gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification</source>
         <target>Cancel</target>
@@ -36,16 +41,6 @@
         <source>gateway.form.gateway_send_sms_challenge.button.send_challenge</source>
         <target>Send code</target>
         <jms:reference-file line="30">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/SendSmsChallengeType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="7039a04e477c52544533b4969fb09c19f34d1452" resname="gateway.form.gateway_send_sms_challenge.label.phone_number">
-        <source>gateway.form.gateway_send_sms_challenge.label.phone_number</source>
-        <target>Phone number</target>
-        <jms:reference-file line="28">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="ddf7dd3f1b77196052dad82522de3845661976fa" resname="gateway.form.send_sms_challenge.button.cancel">
-        <source>gateway.form.send_sms_challenge.button.cancel</source>
-        <target>Cancel</target>
-        <jms:reference-file line="34">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/SendSmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="369b2c8dea153b42d8dc01645e54140a83cb5f4f" resname="gateway.form.send_sms_challenge.sms_challenge_expired">
         <source>gateway.form.send_sms_challenge.sms_challenge_expired</source>
@@ -69,7 +64,7 @@
       </trans-unit>
       <trans-unit id="815ec86e9c26021d75afe4356d9ae3bbb93e9582" resname="gateway.form.verify_sms_challenge.button.cancel">
         <source>gateway.form.verify_sms_challenge.button.cancel</source>
-        <target>Cancel</target>
+        <target state="new">gateway.form.verify_sms_challenge.button.cancel</target>
         <jms:reference-file line="46">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="949d225017cfbb80ae094b1af62b758c4ab1cd2c" resname="gateway.form.verify_sms_challenge.button.resend_challenge">
@@ -188,18 +183,8 @@
       </trans-unit>
       <trans-unit id="fecb0bb6d9524901050c51767a3cf1eceb80da04" resname="gateway.second_factor.sms.send_challenge.title">
         <source>gateway.second_factor.sms.send_challenge.title</source>
-        <target>Verify SMS</target>
-        <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="fbc134b1f4a8c33e94e122042462cd21c853204a" resname="gateway.second_factor.sms.text.after_pressing_proceed">
-        <source>gateway.second_factor.sms.text.after_pressing_proceed</source>
-        <target>After clicking “Send code”, you will receive a text message with a code. On the next page, please enter this code.</target>
-        <jms:reference-file line="12">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="d80ea1ea4e3e600845fc1d86d0851f446f7a8908" resname="gateway.second_factor.sms.text.ensure_phone_has_signal">
-        <source>gateway.second_factor.sms.text.ensure_phone_has_signal</source>
-        <target>Please ensure your mobile phone has a signal and can receive text messages.</target>
-        <jms:reference-file line="11">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <target>Login with SMS</target>
+        <jms:reference-file line="5">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="125a385345b59621d0a18ef5608a775eb04b5f25" resname="gateway.second_factor.sms.text.enter_challenge_below">
         <source>gateway.second_factor.sms.text.enter_challenge_below</source>
@@ -213,13 +198,18 @@
       </trans-unit>
       <trans-unit id="ae96304b72fa22655facaecca34b948409c3deaa" resname="gateway.second_factor.sms.text.help_user_enter_phone_number">
         <source>gateway.second_factor.sms.text.help_user_enter_phone_number</source>
-        <target>Follow the instructions below to verify the possession of your phone:</target>
-        <jms:reference-file line="8">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <target>Send a SMS text message to my mobile phonenumber ending in %phone_number%:</target>
+        <jms:reference-file line="9">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="9051ae99f49586015373858f030ea4fe3b097729" resname="gateway.second_factor.sms.text.next_step">
+        <source>gateway.second_factor.sms.text.next_step</source>
+        <target>Enter the received code on the next page</target>
+        <jms:reference-file line="23">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0d06981098d22a2fa3428068bbc7e53d8cff3db7" resname="gateway.second_factor.sms.text.otp_requests_remaining">
         <source>gateway.second_factor.sms.text.otp_requests_remaining</source>
         <target>Attempts remaining: %count%</target>
-        <jms:reference-file line="19">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
         <jms:reference-file line="12">/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a215b416978f2c35a0ffd4be8576c8a0bdf64718" resname="gateway.second_factor.sms.text.retry_if_not_received">

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -173,7 +173,7 @@
       </trans-unit>
       <trans-unit id="fecb0bb6d9524901050c51767a3cf1eceb80da04" resname="gateway.second_factor.sms.send_challenge.title">
         <source>gateway.second_factor.sms.send_challenge.title</source>
-        <target>Login with SMS</target>
+        <target>Log in with SMS</target>
         <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b709c9885083cad3cea28a08aa1cf07d43fa186f" resname="gateway.second_factor.sms.text.help_user_enter_challenge">
@@ -183,12 +183,12 @@
       </trans-unit>
       <trans-unit id="ae96304b72fa22655facaecca34b948409c3deaa" resname="gateway.second_factor.sms.text.help_user_enter_phone_number">
         <source>gateway.second_factor.sms.text.help_user_enter_phone_number</source>
-        <target>Send a SMS text message to my mobile phonenumber ending in %phone_number%:</target>
+        <target>Send a code to my mobile phone number ending in %phone_number%:</target>
         <jms:reference-file line="6">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9051ae99f49586015373858f030ea4fe3b097729" resname="gateway.second_factor.sms.text.next_step">
         <source>gateway.second_factor.sms.text.next_step</source>
-        <target>Enter the received code on the next page</target>
+        <target>Enter the received code on the next page.</target>
         <jms:reference-file line="18">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0d06981098d22a2fa3428068bbc7e53d8cff3db7" resname="gateway.second_factor.sms.text.otp_requests_remaining">

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-27T14:47:28Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-03-27T15:58:01Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -86,11 +86,6 @@
         <source>gateway.form.verify_yubikey.public_id_mismatch</source>
         <target>You used another Yubikey than you used during your registration process.</target>
         <jms:reference-file line="5">/Resources/views/translations.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="4b7b462d7958d591725738f5b1e3334abeb57160" resname="gateway.form.verify_yubikey_otp.button.cancel">
-        <source>gateway.form.verify_yubikey_otp.button.cancel</source>
-        <target>Cancel</target>
-        <jms:reference-file line="46">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifyYubikeyOtpType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="53c1b4469c10803f2e6bfb5fd31afb68c7f9556f" resname="gateway.gateway.consume_assertion.title">
         <source>gateway.gateway.consume_assertion.title</source>
@@ -234,23 +229,28 @@
       </trans-unit>
       <trans-unit id="be12899784c0176e20b93e0030a2144365add26d" resname="gateway.second_factor.yubikey.text.connect_yubikey_to_pc">
         <source>gateway.second_factor.yubikey.text.connect_yubikey_to_pc</source>
-        <target>Connect your personal YubiKey with the computer.</target>
-        <jms:reference-file line="11">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+        <target>Connect your YubiKey to the USB-port of your computer.</target>
+        <jms:reference-file line="19">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6204e24e7c7b389809232589df868be2b511cdf5" resname="gateway.second_factor.yubikey.text.ensure_form_field_focus">
         <source>gateway.second_factor.yubikey.text.ensure_form_field_focus</source>
-        <target>Please ensure that the form field below is focussed.</target>
-        <jms:reference-file line="12">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+        <target>Make sure that the form field above has focus.</target>
+        <jms:reference-file line="20">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="96f63ed3f7e0e48ded0b2214a9b2b1a60c8b8b29" resname="gateway.second_factor.yubikey.text.enter_challenge">
+        <source>gateway.second_factor.yubikey.text.enter_challenge</source>
+        <target>Your YubiKey-code:</target>
+        <jms:reference-file line="7">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1445676eeee2335e0d37dad8c7d7bf883ea69c40" resname="gateway.second_factor.yubikey.text.help_user_enter_challenge">
         <source>gateway.second_factor.yubikey.text.help_user_enter_challenge</source>
-        <target>Use your YubiKey to login:</target>
-        <jms:reference-file line="8">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+        <target>How to use your YubiKey:</target>
+        <jms:reference-file line="17">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2845155cc34878dd2e86f19ca5ea1b01c2039d01" resname="gateway.second_factor.yubikey.text.press_once_form_auto_submitted">
         <source>gateway.second_factor.yubikey.text.press_once_form_auto_submitted</source>
-        <target>Press the button on your YubiKey once to enter an OTP in the field below.</target>
-        <jms:reference-file line="13">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+        <target>Press the button on your YubiKey and hold shortly. A code is automatically generated and entered into the field above.</target>
+        <jms:reference-file line="21">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46afcd414845fe64dedd737b959f7cd327b85a63" resname="gateway.submit.click_to_go_back_to_sp">
         <source>gateway.submit.click_to_go_back_to_sp</source>
@@ -284,7 +284,7 @@
       </trans-unit>
       <trans-unit id="ee8b15d139dd5ba69eb2bfbc1c540b03894bafd7" resname="ra.registration.yubikey.title.enter_challenge">
         <source>ra.registration.yubikey.title.enter_challenge</source>
-        <target>Use your YubiKey to login</target>
+        <target>Log in with YubiKey</target>
         <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c50aaca50072a446eab71327c6bfc5e5de8698f5" resname="stepup.error.authentication_error.description">

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-27T11:03:27Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-03-27T14:47:28Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -25,7 +25,7 @@
       <trans-unit id="7ae5055bfdf6e6100256f6148115dfaa4b06ac52" resname="gateway.form.cancel_authentication.button.cancel">
         <source>gateway.form.cancel_authentication.button.cancel</source>
         <target>Cancel</target>
-        <jms:reference-file line="30">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/CancelAuthenticationType.php</jms:reference-file>
+        <jms:reference-file line="29">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/CancelAuthenticationType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="65f3ce4b0efbcaaaafd540e24188ea54d0851540" resname="gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification">
         <source>gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification</source>
@@ -62,25 +62,20 @@
         <target>You have exceeded the limit of ten attempts; you can no longer attempt verification of any more codes. Contact your helpdesk or try again later.</target>
         <jms:reference-file line="11">/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="815ec86e9c26021d75afe4356d9ae3bbb93e9582" resname="gateway.form.verify_sms_challenge.button.cancel">
-        <source>gateway.form.verify_sms_challenge.button.cancel</source>
-        <target state="new">gateway.form.verify_sms_challenge.button.cancel</target>
-        <jms:reference-file line="46">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
+      <trans-unit id="794d606d42626487d338b79f4b39ece27fd6da94" resname="gateway.form.verify_sms_challenge.button.challenge_placeholder">
+        <source>gateway.form.verify_sms_challenge.button.challenge_placeholder</source>
+        <target>code</target>
+        <jms:reference-file line="34">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="949d225017cfbb80ae094b1af62b758c4ab1cd2c" resname="gateway.form.verify_sms_challenge.button.resend_challenge">
         <source>gateway.form.verify_sms_challenge.button.resend_challenge</source>
-        <target>Request a new code</target>
-        <jms:reference-file line="41">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
+        <target>Send again.</target>
+        <jms:reference-file line="42">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c112fb5c4f9e2eca7afdf9e31f1eb7c17078b647" resname="gateway.form.verify_sms_challenge.button.verify_challenge">
         <source>gateway.form.verify_sms_challenge.button.verify_challenge</source>
         <target>Verify code</target>
-        <jms:reference-file line="37">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="1b12b51928c9eb9c6922fd0c910502698f0865f5" resname="gateway.form.verify_sms_challenge.text.challenge">
-        <source>gateway.form.verify_sms_challenge.text.challenge</source>
-        <target>Code</target>
-        <jms:reference-file line="30">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
+        <jms:reference-file line="38">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="69e4a91f05f1619fc6326ff78659255bc0d4f7ce" resname="gateway.form.verify_yubikey.otp_verification_failed">
         <source>gateway.form.verify_yubikey.otp_verification_failed</source>
@@ -184,42 +179,37 @@
       <trans-unit id="fecb0bb6d9524901050c51767a3cf1eceb80da04" resname="gateway.second_factor.sms.send_challenge.title">
         <source>gateway.second_factor.sms.send_challenge.title</source>
         <target>Login with SMS</target>
-        <jms:reference-file line="5">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="125a385345b59621d0a18ef5608a775eb04b5f25" resname="gateway.second_factor.sms.text.enter_challenge_below">
-        <source>gateway.second_factor.sms.text.enter_challenge_below</source>
-        <target>Enter the code below.</target>
-        <jms:reference-file line="11">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b709c9885083cad3cea28a08aa1cf07d43fa186f" resname="gateway.second_factor.sms.text.help_user_enter_challenge">
         <source>gateway.second_factor.sms.text.help_user_enter_challenge</source>
-        <target>You just received a SMS code. Please use this code to login:</target>
-        <jms:reference-file line="8">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
+        <target>Enter the received SMS-code:</target>
+        <jms:reference-file line="6">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae96304b72fa22655facaecca34b948409c3deaa" resname="gateway.second_factor.sms.text.help_user_enter_phone_number">
         <source>gateway.second_factor.sms.text.help_user_enter_phone_number</source>
         <target>Send a SMS text message to my mobile phonenumber ending in %phone_number%:</target>
-        <jms:reference-file line="9">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9051ae99f49586015373858f030ea4fe3b097729" resname="gateway.second_factor.sms.text.next_step">
         <source>gateway.second_factor.sms.text.next_step</source>
         <target>Enter the received code on the next page</target>
-        <jms:reference-file line="23">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0d06981098d22a2fa3428068bbc7e53d8cff3db7" resname="gateway.second_factor.sms.text.otp_requests_remaining">
         <source>gateway.second_factor.sms.text.otp_requests_remaining</source>
         <target>Attempts remaining: %count%</target>
-        <jms:reference-file line="13">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
         <jms:reference-file line="12">/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="a215b416978f2c35a0ffd4be8576c8a0bdf64718" resname="gateway.second_factor.sms.text.retry_if_not_received">
-        <source>gateway.second_factor.sms.text.retry_if_not_received</source>
-        <target>Request another code if you don't receive a text message within one minute.</target>
-        <jms:reference-file line="12">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
+      <trans-unit id="c2e588b8944c77908c7aa5d45de4123f29ffc1f6" resname="gateway.second_factor.sms.text.resend_challenge_text">
+        <source>gateway.second_factor.sms.text.resend_challenge_text</source>
+        <target>No code received?</target>
+        <jms:reference-file line="15">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c9ecf89d8bcda5d83b5a78f10fda52522011fcc7" resname="gateway.second_factor.sms.verify_challenge.title.page">
         <source>gateway.second_factor.sms.verify_challenge.title.page</source>
-        <target>Verify SMS-code</target>
+        <target>Log in with SMS</target>
         <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d0af79ae0b3f333a17355d24f9fd8cea1311dc48" resname="gateway.second_factor.u2f.button.retry">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -54,7 +54,7 @@
       </trans-unit>
       <trans-unit id="b8020a5c4b1ce8f6a3cfa6854588499b9a6168ef" resname="gateway.form.send_sms_challenge.sms_sending_failed">
         <source>gateway.form.send_sms_challenge.sms_sending_failed</source>
-        <target>Het versturen van de SMS-code is mislukt.</target>
+        <target>Het versturen van de sms-code is mislukt.</target>
         <jms:reference-file line="8">/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="be86ce24f39578ecbfb3cf0ad710a5a96e819ff6" resname="gateway.form.send_sms_challenge.too_many_attempts">
@@ -153,7 +153,7 @@
       </trans-unit>
       <trans-unit id="7b77bca359dd095ce5a10f57ed44386bf8aac3a1" resname="gateway.second_factor.search.type.sms">
         <source>gateway.second_factor.search.type.sms</source>
-        <target>SMS</target>
+        <target>sms</target>
         <jms:reference-file line="23">/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="72a21f0cbb338b0b94a2e55e9d1f8e48baf34eaa" resname="gateway.second_factor.search.type.u2f">
@@ -168,12 +168,12 @@
       </trans-unit>
       <trans-unit id="1c41e8d2b8040894426471450740d39af284d440" resname="gateway.second_factor.sms.challenge_body">
         <source>gateway.second_factor.sms.challenge_body</source>
-        <target>Je SMS-code: %challenge%</target>
+        <target>Je sms-code: %challenge%</target>
         <jms:reference-file line="401">/../src/Surfnet/StepupGateway/GatewayBundle/Service/StepUpAuthenticationService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fecb0bb6d9524901050c51767a3cf1eceb80da04" resname="gateway.second_factor.sms.send_challenge.title">
         <source>gateway.second_factor.sms.send_challenge.title</source>
-        <target>Login met SMS</target>
+        <target>Login met sms</target>
         <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b709c9885083cad3cea28a08aa1cf07d43fa186f" resname="gateway.second_factor.sms.text.help_user_enter_challenge">
@@ -183,7 +183,7 @@
       </trans-unit>
       <trans-unit id="ae96304b72fa22655facaecca34b948409c3deaa" resname="gateway.second_factor.sms.text.help_user_enter_phone_number">
         <source>gateway.second_factor.sms.text.help_user_enter_phone_number</source>
-        <target>Stuur een SMS login code naar mijn mobiel nummer eindigend op %phone_number%:</target>
+        <target>Stuur een code naar mijn mobiel nummer eindigend op %phone_number%:</target>
         <jms:reference-file line="6">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9051ae99f49586015373858f030ea4fe3b097729" resname="gateway.second_factor.sms.text.next_step">
@@ -204,7 +204,7 @@
       </trans-unit>
       <trans-unit id="c9ecf89d8bcda5d83b5a78f10fda52522011fcc7" resname="gateway.second_factor.sms.verify_challenge.title.page">
         <source>gateway.second_factor.sms.verify_challenge.title.page</source>
-        <target>Log in met SMS</target>
+        <target>Log in met sms</target>
         <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d0af79ae0b3f333a17355d24f9fd8cea1311dc48" resname="gateway.second_factor.u2f.button.retry">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-23T09:48:46Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-03-27T11:03:23Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -22,6 +22,11 @@
         <target>Login-response kan niet worden verwerkt.</target>
         <jms:reference-file line="7">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/unprocessableResponse.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="7ae5055bfdf6e6100256f6148115dfaa4b06ac52" resname="gateway.form.cancel_authentication.button.cancel">
+        <source>gateway.form.cancel_authentication.button.cancel</source>
+        <target>Annuleren</target>
+        <jms:reference-file line="30">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/CancelAuthenticationType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="65f3ce4b0efbcaaaafd540e24188ea54d0851540" resname="gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification">
         <source>gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification</source>
         <target>Annuleren</target>
@@ -36,16 +41,6 @@
         <source>gateway.form.gateway_send_sms_challenge.button.send_challenge</source>
         <target>Stuur code</target>
         <jms:reference-file line="30">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/SendSmsChallengeType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="7039a04e477c52544533b4969fb09c19f34d1452" resname="gateway.form.gateway_send_sms_challenge.label.phone_number">
-        <source>gateway.form.gateway_send_sms_challenge.label.phone_number</source>
-        <target>Telefoonnummer</target>
-        <jms:reference-file line="28">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="ddf7dd3f1b77196052dad82522de3845661976fa" resname="gateway.form.send_sms_challenge.button.cancel">
-        <source>gateway.form.send_sms_challenge.button.cancel</source>
-        <target>Annuleren</target>
-        <jms:reference-file line="34">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/SendSmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="369b2c8dea153b42d8dc01645e54140a83cb5f4f" resname="gateway.form.send_sms_challenge.sms_challenge_expired">
         <source>gateway.form.send_sms_challenge.sms_challenge_expired</source>
@@ -69,7 +64,7 @@
       </trans-unit>
       <trans-unit id="815ec86e9c26021d75afe4356d9ae3bbb93e9582" resname="gateway.form.verify_sms_challenge.button.cancel">
         <source>gateway.form.verify_sms_challenge.button.cancel</source>
-        <target>Annuleren</target>
+        <target state="new">gateway.form.verify_sms_challenge.button.cancel</target>
         <jms:reference-file line="46">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="949d225017cfbb80ae094b1af62b758c4ab1cd2c" resname="gateway.form.verify_sms_challenge.button.resend_challenge">
@@ -188,18 +183,8 @@
       </trans-unit>
       <trans-unit id="fecb0bb6d9524901050c51767a3cf1eceb80da04" resname="gateway.second_factor.sms.send_challenge.title">
         <source>gateway.second_factor.sms.send_challenge.title</source>
-        <target>SMS verifiëren</target>
-        <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="fbc134b1f4a8c33e94e122042462cd21c853204a" resname="gateway.second_factor.sms.text.after_pressing_proceed">
-        <source>gateway.second_factor.sms.text.after_pressing_proceed</source>
-        <target>Na op “Stuur code” te hebben geklikt ontvang je een tekstbericht met een code. Vul deze code op de volgende pagina in.</target>
-        <jms:reference-file line="12">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="d80ea1ea4e3e600845fc1d86d0851f446f7a8908" resname="gateway.second_factor.sms.text.ensure_phone_has_signal">
-        <source>gateway.second_factor.sms.text.ensure_phone_has_signal</source>
-        <target>Controleer dat je telefoon bereik heeft en tekstberichten kan ontvangen.</target>
-        <jms:reference-file line="11">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <target>Login met SMS</target>
+        <jms:reference-file line="5">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="125a385345b59621d0a18ef5608a775eb04b5f25" resname="gateway.second_factor.sms.text.enter_challenge_below">
         <source>gateway.second_factor.sms.text.enter_challenge_below</source>
@@ -213,13 +198,18 @@
       </trans-unit>
       <trans-unit id="ae96304b72fa22655facaecca34b948409c3deaa" resname="gateway.second_factor.sms.text.help_user_enter_phone_number">
         <source>gateway.second_factor.sms.text.help_user_enter_phone_number</source>
-        <target>Volg onderstaande instructies om het bezit van je telefoon aan te tonen.</target>
-        <jms:reference-file line="8">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <target>Stuur een SMS login code naar mijn mobiel nummer eindigend op %phone_number%:</target>
+        <jms:reference-file line="9">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="9051ae99f49586015373858f030ea4fe3b097729" resname="gateway.second_factor.sms.text.next_step">
+        <source>gateway.second_factor.sms.text.next_step</source>
+        <target>Vul de ontvangen code in op de volgende pagina.</target>
+        <jms:reference-file line="23">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0d06981098d22a2fa3428068bbc7e53d8cff3db7" resname="gateway.second_factor.sms.text.otp_requests_remaining">
         <source>gateway.second_factor.sms.text.otp_requests_remaining</source>
         <target>Aantal resterende pogingen: %count%</target>
-        <jms:reference-file line="19">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
         <jms:reference-file line="12">/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a215b416978f2c35a0ffd4be8576c8a0bdf64718" resname="gateway.second_factor.sms.text.retry_if_not_received">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-27T14:47:24Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-03-27T15:57:58Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -86,11 +86,6 @@
         <source>gateway.form.verify_yubikey.public_id_mismatch</source>
         <target>Je gebruikt nu een andere YubiKey dan tijdens het registratieproces.</target>
         <jms:reference-file line="5">/Resources/views/translations.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="4b7b462d7958d591725738f5b1e3334abeb57160" resname="gateway.form.verify_yubikey_otp.button.cancel">
-        <source>gateway.form.verify_yubikey_otp.button.cancel</source>
-        <target>Annuleren</target>
-        <jms:reference-file line="46">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifyYubikeyOtpType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="53c1b4469c10803f2e6bfb5fd31afb68c7f9556f" resname="gateway.gateway.consume_assertion.title">
         <source>gateway.gateway.consume_assertion.title</source>
@@ -235,22 +230,27 @@
       <trans-unit id="be12899784c0176e20b93e0030a2144365add26d" resname="gateway.second_factor.yubikey.text.connect_yubikey_to_pc">
         <source>gateway.second_factor.yubikey.text.connect_yubikey_to_pc</source>
         <target>Stop je YubiKey in een USB-poort van je computer.</target>
-        <jms:reference-file line="11">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="19">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6204e24e7c7b389809232589df868be2b511cdf5" resname="gateway.second_factor.yubikey.text.ensure_form_field_focus">
         <source>gateway.second_factor.yubikey.text.ensure_form_field_focus</source>
         <target>Zorg dat het invulveld hieronder actief is.</target>
-        <jms:reference-file line="12">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="96f63ed3f7e0e48ded0b2214a9b2b1a60c8b8b29" resname="gateway.second_factor.yubikey.text.enter_challenge">
+        <source>gateway.second_factor.yubikey.text.enter_challenge</source>
+        <target>Je YubiKey-code:</target>
+        <jms:reference-file line="7">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1445676eeee2335e0d37dad8c7d7bf883ea69c40" resname="gateway.second_factor.yubikey.text.help_user_enter_challenge">
         <source>gateway.second_factor.yubikey.text.help_user_enter_challenge</source>
-        <target>Gebruik je YubiKey om in te loggen:</target>
-        <jms:reference-file line="8">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+        <target>Je YubiKey gebruik je zo:</target>
+        <jms:reference-file line="17">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2845155cc34878dd2e86f19ca5ea1b01c2039d01" resname="gateway.second_factor.yubikey.text.press_once_form_auto_submitted">
         <source>gateway.second_factor.yubikey.text.press_once_form_auto_submitted</source>
         <target>Druk op de knop van je YubiKey en houd even vast. Er verschijnt automatisch een eenmalige code in het invulveld.</target>
-        <jms:reference-file line="13">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46afcd414845fe64dedd737b959f7cd327b85a63" resname="gateway.submit.click_to_go_back_to_sp">
         <source>gateway.submit.click_to_go_back_to_sp</source>
@@ -284,7 +284,7 @@
       </trans-unit>
       <trans-unit id="ee8b15d139dd5ba69eb2bfbc1c540b03894bafd7" resname="ra.registration.yubikey.title.enter_challenge">
         <source>ra.registration.yubikey.title.enter_challenge</source>
-        <target>Log in met je YubiKey</target>
+        <target>Log in met YubiKey</target>
         <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c50aaca50072a446eab71327c6bfc5e5de8698f5" resname="stepup.error.authentication_error.description">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-27T11:03:23Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-03-27T14:47:24Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -25,7 +25,7 @@
       <trans-unit id="7ae5055bfdf6e6100256f6148115dfaa4b06ac52" resname="gateway.form.cancel_authentication.button.cancel">
         <source>gateway.form.cancel_authentication.button.cancel</source>
         <target>Annuleren</target>
-        <jms:reference-file line="30">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/CancelAuthenticationType.php</jms:reference-file>
+        <jms:reference-file line="29">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/CancelAuthenticationType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="65f3ce4b0efbcaaaafd540e24188ea54d0851540" resname="gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification">
         <source>gateway.form.gateway_cancel_second_factor_verification.button.cancel_verification</source>
@@ -62,25 +62,20 @@
         <target>De limiet van tien pogingen is bereikt; je kunt geen codes meer verifiëren. Neem contact op met de helpdesk van je installing of probeer het later nog eens.</target>
         <jms:reference-file line="11">/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="815ec86e9c26021d75afe4356d9ae3bbb93e9582" resname="gateway.form.verify_sms_challenge.button.cancel">
-        <source>gateway.form.verify_sms_challenge.button.cancel</source>
-        <target state="new">gateway.form.verify_sms_challenge.button.cancel</target>
-        <jms:reference-file line="46">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
+      <trans-unit id="794d606d42626487d338b79f4b39ece27fd6da94" resname="gateway.form.verify_sms_challenge.button.challenge_placeholder">
+        <source>gateway.form.verify_sms_challenge.button.challenge_placeholder</source>
+        <target>code</target>
+        <jms:reference-file line="34">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="949d225017cfbb80ae094b1af62b758c4ab1cd2c" resname="gateway.form.verify_sms_challenge.button.resend_challenge">
         <source>gateway.form.verify_sms_challenge.button.resend_challenge</source>
-        <target>Vraag een nieuwe code aan</target>
-        <jms:reference-file line="41">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
+        <target>Stuur nogmaals.</target>
+        <jms:reference-file line="42">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c112fb5c4f9e2eca7afdf9e31f1eb7c17078b647" resname="gateway.form.verify_sms_challenge.button.verify_challenge">
         <source>gateway.form.verify_sms_challenge.button.verify_challenge</source>
-        <target>Code verifiëren</target>
-        <jms:reference-file line="37">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="1b12b51928c9eb9c6922fd0c910502698f0865f5" resname="gateway.form.verify_sms_challenge.text.challenge">
-        <source>gateway.form.verify_sms_challenge.text.challenge</source>
-        <target>Code</target>
-        <jms:reference-file line="30">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
+        <target>Verifieer code</target>
+        <jms:reference-file line="38">/../src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="69e4a91f05f1619fc6326ff78659255bc0d4f7ce" resname="gateway.form.verify_yubikey.otp_verification_failed">
         <source>gateway.form.verify_yubikey.otp_verification_failed</source>
@@ -184,42 +179,37 @@
       <trans-unit id="fecb0bb6d9524901050c51767a3cf1eceb80da04" resname="gateway.second_factor.sms.send_challenge.title">
         <source>gateway.second_factor.sms.send_challenge.title</source>
         <target>Login met SMS</target>
-        <jms:reference-file line="5">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="125a385345b59621d0a18ef5608a775eb04b5f25" resname="gateway.second_factor.sms.text.enter_challenge_below">
-        <source>gateway.second_factor.sms.text.enter_challenge_below</source>
-        <target>Voer de code hieronder in.</target>
-        <jms:reference-file line="11">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b709c9885083cad3cea28a08aa1cf07d43fa186f" resname="gateway.second_factor.sms.text.help_user_enter_challenge">
         <source>gateway.second_factor.sms.text.help_user_enter_challenge</source>
-        <target>Je hebt net een SMS-code ontvangen. Gebruik deze om in te loggen:</target>
-        <jms:reference-file line="8">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
+        <target>Vul de ontvangen sms-code in:</target>
+        <jms:reference-file line="6">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae96304b72fa22655facaecca34b948409c3deaa" resname="gateway.second_factor.sms.text.help_user_enter_phone_number">
         <source>gateway.second_factor.sms.text.help_user_enter_phone_number</source>
         <target>Stuur een SMS login code naar mijn mobiel nummer eindigend op %phone_number%:</target>
-        <jms:reference-file line="9">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9051ae99f49586015373858f030ea4fe3b097729" resname="gateway.second_factor.sms.text.next_step">
         <source>gateway.second_factor.sms.text.next_step</source>
         <target>Vul de ontvangen code in op de volgende pagina.</target>
-        <jms:reference-file line="23">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0d06981098d22a2fa3428068bbc7e53d8cff3db7" resname="gateway.second_factor.sms.text.otp_requests_remaining">
         <source>gateway.second_factor.sms.text.otp_requests_remaining</source>
         <target>Aantal resterende pogingen: %count%</target>
-        <jms:reference-file line="13">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig</jms:reference-file>
         <jms:reference-file line="12">/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="a215b416978f2c35a0ffd4be8576c8a0bdf64718" resname="gateway.second_factor.sms.text.retry_if_not_received">
-        <source>gateway.second_factor.sms.text.retry_if_not_received</source>
-        <target>Vraag een nieuwe code aan als je niet binnen een minuut een bericht ontvangt.</target>
-        <jms:reference-file line="12">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
+      <trans-unit id="c2e588b8944c77908c7aa5d45de4123f29ffc1f6" resname="gateway.second_factor.sms.text.resend_challenge_text">
+        <source>gateway.second_factor.sms.text.resend_challenge_text</source>
+        <target>Geen code ontvangen?</target>
+        <jms:reference-file line="15">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c9ecf89d8bcda5d83b5a78f10fda52522011fcc7" resname="gateway.second_factor.sms.verify_challenge.title.page">
         <source>gateway.second_factor.sms.verify_challenge.title.page</source>
-        <target>Bevestig code</target>
+        <target>Log in met SMS</target>
         <jms:reference-file line="3">/../src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d0af79ae0b3f333a17355d24f9fd8cea1311dc48" resname="gateway.second_factor.u2f.button.retry">

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -34,6 +34,7 @@ use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
 use Surfnet\StepupGateway\U2fVerificationBundle\Value\KeyHandle;
 use Surfnet\StepupU2fBundle\Dto\SignResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -313,14 +314,11 @@ class SecondFactorController extends Controller
         $command->secondFactorId = $selectedSecondFactor;
 
         $form = $this->createForm('gateway_verify_yubikey_otp', $command)->handleRequest($request);
-
-        if ($form->get('cancel')->isClicked()) {
-            return $this->forward('SurfnetStepupGatewayGatewayBundle:Gateway:sendAuthenticationCancelledByUser');
-        }
+        $cancelForm = $this->buildCancelAuthenticationForm()->handleRequest($request);
 
         if (!$form->isValid()) {
             // OTP field is rendered empty in the template.
-            return ['form' => $form->createView()];
+            return ['form' => $form->createView(), 'cancelForm' => $cancelForm->createView()];
         }
 
         $result = $this->getStepupService()->verifyYubikeyOtp($command);
@@ -329,12 +327,12 @@ class SecondFactorController extends Controller
             $form->addError(new FormError('gateway.form.verify_yubikey.otp_verification_failed'));
 
             // OTP field is rendered empty in the template.
-            return ['form' => $form->createView()];
+            return ['form' => $form->createView(), 'cancelForm' => $cancelForm->createView()];
         } elseif (!$result->didPublicIdMatch()) {
             $form->addError(new FormError('gateway.form.verify_yubikey.public_id_mismatch'));
 
             // OTP field is rendered empty in the template.
-            return ['form' => $form->createView()];
+            return ['form' => $form->createView(), 'cancelForm' => $cancelForm->createView()];
         }
 
         $this->getResponseContext()->markSecondFactorVerified();
@@ -371,13 +369,7 @@ class SecondFactorController extends Controller
         $command->secondFactorId = $selectedSecondFactor;
 
         $form = $this->createForm('gateway_send_sms_challenge', $command)->handleRequest($request);
-
-        $cancelFormAction = $this->generateUrl('gateway_cancel_authentication');
-        $cancelForm = $this->createForm(
-            'gateway_cancel_authentication',
-            null,
-            ['action' => $cancelFormAction]
-        )->handleRequest($request);
+        $cancelForm = $this->buildCancelAuthenticationForm()->handleRequest($request);
 
         $stepupService = $this->getStepupService();
         $phoneNumber = InternationalPhoneNumber::fromStringFormat(
@@ -426,13 +418,7 @@ class SecondFactorController extends Controller
 
         $command = new VerifyPossessionOfPhoneCommand();
         $form = $this->createForm('gateway_verify_sms_challenge', $command)->handleRequest($request);
-
-        $cancelFormAction = $this->generateUrl('gateway_cancel_authentication');
-        $cancelForm = $this->createForm(
-            'gateway_cancel_authentication',
-            null,
-            ['action' => $cancelFormAction]
-        )->handleRequest($request);
+        $cancelForm = $this->buildCancelAuthenticationForm()->handleRequest($request);
 
         if (!$form->isValid()) {
             return ['form' => $form->createView(), 'cancelForm' => $cancelForm->createView()];
@@ -655,5 +641,19 @@ class SecondFactorController extends Controller
         }
 
         return $this->redirect($this->generateUrl($route));
+    }
+
+    /**
+     * @return Form
+     */
+    private function buildCancelAuthenticationForm()
+    {
+        $cancelFormAction = $this->generateUrl('gateway_cancel_authentication');
+        $cancelForm = $this->createForm(
+            'gateway_cancel_authentication',
+            null,
+            ['action' => $cancelFormAction]
+        );
+        return $cancelForm;
     }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -427,12 +427,15 @@ class SecondFactorController extends Controller
         $command = new VerifyPossessionOfPhoneCommand();
         $form = $this->createForm('gateway_verify_sms_challenge', $command)->handleRequest($request);
 
-        if ($form->get('cancel')->isClicked()) {
-            return $this->forward('SurfnetStepupGatewayGatewayBundle:Gateway:sendAuthenticationCancelledByUser');
-        }
+        $cancelFormAction = $this->generateUrl('gateway_cancel_authentication');
+        $cancelForm = $this->createForm(
+            'gateway_cancel_authentication',
+            null,
+            ['action' => $cancelFormAction]
+        )->handleRequest($request);
 
         if (!$form->isValid()) {
-            return ['form' => $form->createView()];
+            return ['form' => $form->createView(), 'cancelForm' => $cancelForm->createView()];
         }
 
         $logger->notice('Verifying input SMS challenge matches');
@@ -464,7 +467,7 @@ class SecondFactorController extends Controller
             $form->addError(new FormError('gateway.form.send_sms_challenge.sms_challenge_incorrect'));
         }
 
-        return ['form' => $form->createView()];
+        return ['form' => $form->createView(), 'cancelForm' => $cancelForm->createView()];
     }
 
     /**

--- a/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/CancelAuthenticationType.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/CancelAuthenticationType.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class CancelAuthenticationType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('cancel', 'submit', [
+            'label' => 'gateway.form.cancel_authentication.button.cancel',
+            'attr'  => ['class' => 'btn-link nav-link', 'formnovalidate' => 'formnovalidate'],
+        ]);
+    }
+
+    public function getName()
+    {
+        return 'gateway_cancel_authentication';
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/SendSmsChallengeType.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/SendSmsChallengeType.php
@@ -26,13 +26,9 @@ class SendSmsChallengeType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('send-challenge', 'submit', [
+        $builder->add('send_challenge', 'submit', [
             'label' => 'gateway.form.gateway_send_sms_challenge.button.send_challenge',
-            'attr' => [ 'class' => 'btn btn-primary pull-right' ],
-        ]);
-        $builder->add('cancel', 'submit', [
-            'label' => 'gateway.form.send_sms_challenge.button.cancel',
-            'attr'  => ['class' => 'btn btn-danger', 'formnovalidate' => 'formnovalidate'],
+            'attr' => [ 'class' => 'btn btn-primary' ],
         ]);
     }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php
@@ -27,24 +27,21 @@ class VerifySmsChallengeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('challenge', 'text', [
-            'label'    => 'gateway.form.verify_sms_challenge.text.challenge',
+            'label'    => false,
             'required' => true,
             'attr'     => array(
                 'autofocus' => true,
+                'placeholder' => 'gateway.form.verify_sms_challenge.button.challenge_placeholder'
             )
         ]);
-        $builder->add('verify-challenge', 'submit', [
+        $builder->add('verify_challenge', 'submit', [
             'label' => 'gateway.form.verify_sms_challenge.button.verify_challenge',
-            'attr'  => ['class' => 'btn btn-primary pull-right'],
+            'attr'  => ['class' => 'btn btn-primary'],
         ]);
-        $builder->add('resend-challenge', 'anchor', [
+        $builder->add('resend_challenge', 'anchor', [
             'label' => 'gateway.form.verify_sms_challenge.button.resend_challenge',
-            'attr'  => ['class' => 'btn btn-default pull-right'],
+            'attr'  => ['class' => 'btn btn-link'],
             'route' => 'gateway_verify_second_factor_sms',
-        ]);
-        $builder->add('cancel', 'submit', [
-            'label' => 'gateway.form.verify_sms_challenge.button.cancel',
-            'attr'  => ['class' => 'btn btn-danger', 'formnovalidate' => 'formnovalidate'],
         ]);
     }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifyYubikeyOtpType.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifyYubikeyOtpType.php
@@ -42,10 +42,6 @@ class VerifyYubikeyOtpType extends AbstractType
         $builder->add('submit', 'submit', [
             'attr'  => ['class' => 'btn btn-off-screen'],
         ]);
-        $builder->add('cancel', 'submit', [
-            'label' => 'gateway.form.verify_yubikey_otp.button.cancel',
-            'attr'  => ['class' => 'btn btn-danger', 'formnovalidate' => 'formnovalidate'],
-        ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/routing.yml
@@ -3,6 +3,11 @@ gateway_saml_metadata:
     methods:  [GET]
     defaults: { _controller: SurfnetStepupGatewayGatewayBundle:Metadata:metadata}
 
+gateway_cancel_authentication:
+    path:     /authentication/cancel
+    methods:  [POST]
+    defaults: { _controller: SurfnetStepupGatewayGatewayBundle:SecondFactor:cancelAuthentication }
+
 gateway_serviceprovider_consume_assertion:
     path:     /authentication/consume-assertion
     methods:  [POST]
@@ -51,7 +56,7 @@ gateway_verify_second_factor_u2f_verify_authentication:
 gateway_verify_second_factor_u2f_cancel_authentication:
     path:     /verify-second-factor/u2f/cancel
     methods:  [POST]
-    defaults: { _controller: SurfnetStepupGatewayGatewayBundle:SecondFactor:cancelU2fAuthentication }
+    defaults: { _controller: SurfnetStepupGatewayGatewayBundle:SecondFactor:cancelAuthentication }
 
 gateway_verify_second_factor_choose_second_factor:
     path:     /choose-second-factor

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
@@ -116,6 +116,10 @@ services:
         class: Surfnet\StepupGateway\GatewayBundle\Form\Type\AnchorType
         tags: [{ name: form.type, alias: anchor }]
 
+    gateway_cancel_authentication:
+        class: Surfnet\StepupGateway\GatewayBundle\Form\Type\CancelAuthenticationType
+        tags: [{ name: form.type, alias: gateway_cancel_authentication }]
+
     gateway.form.verify_yubikey:
         class: Surfnet\StepupGateway\GatewayBundle\Form\Type\VerifyYubikeyOtpType
         tags: [{ name: form.type, alias: gateway_verify_yubikey_otp }]

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/secondFactorAuthentication.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/secondFactorAuthentication.html.twig
@@ -14,12 +14,9 @@
 
 {% block footer %}
     <hr>
-    <ul class="nav nav-pills containing-cancel">
-        <li class="nav-item">
-            {{ form_start(cancelForm) }}
-            {{ form_widget(cancelForm.cancel, {}) }}
-            {{ form_end(cancelForm) }}
-        </li>
-        <li class="nav-item pull-right"><a href="{{ global_view_parameters.supportUrl }}" target="_blank">Help</a></li>
+    {{ form_start(cancelForm) }}
+    {{ form_widget(cancelForm.cancel, {}) }}
+    {{ form_end(cancelForm) }}
+    <a class="pull-right" href="{{ global_view_parameters.supportUrl }}" target="_blank">Help</a>
     </ul>
 {% endblock footer %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/secondFactorAuthentication.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/secondFactorAuthentication.html.twig
@@ -1,0 +1,25 @@
+{% extends "::base.html.twig" %}
+{% block container_class %}{{ parent() }} authentication{% endblock container_class %}
+
+{% block body_tag %}
+<body class="authentication">
+{% endblock body_tag %}
+
+{% block content_row %}
+    <div class="authentication-content">
+        {% block content %}
+        {% endblock content %}
+    </div>
+{% endblock content_row %}
+
+{% block footer %}
+    <hr>
+    <ul class="nav nav-pills containing-cancel">
+        <li class="nav-item">
+            {{ form_start(cancelForm) }}
+            {{ form_widget(cancelForm.cancel, {}) }}
+            {{ form_end(cancelForm) }}
+        </li>
+        <li class="nav-item pull-right"><a href="{{ global_view_parameters.supportUrl }}" target="_blank">Help</a></li>
+    </ul>
+{% endblock footer %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig
@@ -1,34 +1,20 @@
-{% extends "::base.html.twig" %}
+{% extends "@SurfnetStepupGatewayGateway/SecondFactor/secondFactorAuthentication.html.twig" %}
 
 {% block application_name %}{{ 'gateway.second_factor.sms.send_challenge.title'|trans }}{% endblock application_name %}
-
 {% block content %}
 
     <p>{{ 'gateway.second_factor.sms.text.help_user_enter_phone_number'|trans({"%phone_number%": phoneNumber|slice(-4)}) }}</p>
 
     {% if otpRequestsRemaining != maximumOtpRequests %}
         <div class="alert alert-{% if otpRequestsRemaining == 0 %}error{% elseif otpRequestsRemaining == 1 %}warning{% else %}info{% endif %}">
-                {{ 'gateway.second_factor.sms.text.otp_requests_remaining'|trans({ '%count%': otpRequestsRemaining }) }}
-            </div>
+            {{ 'gateway.second_factor.sms.text.otp_requests_remaining'|trans({ '%count%': otpRequestsRemaining }) }}
+        </div>
     {% endif %}
 
     <div class="form-gateway-send-sms-challenge">
-
         {{ form(form) }}
-
     </div>
 
     <p>{{ 'gateway.second_factor.sms.text.next_step'|trans }}</p>
 
 {% endblock %}
-
-{% block footer %}
-    <ul class="nav nav-pills containing-cancel">
-        <li class="nav-item">
-            {{ form_start(cancelForm) }}
-            {{ form_widget(cancelForm.cancel, {}) }}
-            {{ form_end(cancelForm) }}
-        </li>
-        <li class="nav-item"><a href="{{ global_view_parameters.supportUrl }}" target="_blank">Help</a></li>
-    </ul>
-{% endblock footer %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactor.html.twig
@@ -1,18 +1,10 @@
 {% extends "::base.html.twig" %}
 
-{% block page_title %}{{ 'gateway.second_factor.sms.send_challenge.title'|trans }}{% endblock %}
+{% block application_name %}{{ 'gateway.second_factor.sms.send_challenge.title'|trans }}{% endblock application_name %}
 
 {% block content %}
-    <h2>{{ block('page_title') }}</h2>
 
-    <p>{{ 'gateway.second_factor.sms.text.help_user_enter_phone_number'|trans }}</p>
-
-    <ol>
-        <li>{{ 'gateway.second_factor.sms.text.ensure_phone_has_signal'|trans }}</li>
-        <li>{{ 'gateway.second_factor.sms.text.after_pressing_proceed'|trans }}</li>
-    </ol>
-
-    <hr>
+    <p>{{ 'gateway.second_factor.sms.text.help_user_enter_phone_number'|trans({"%phone_number%": phoneNumber|slice(-4)}) }}</p>
 
     {% if otpRequestsRemaining != maximumOtpRequests %}
         <div class="alert alert-{% if otpRequestsRemaining == 0 %}error{% elseif otpRequestsRemaining == 1 %}warning{% else %}info{% endif %}">
@@ -22,17 +14,21 @@
 
     <div class="form-gateway-send-sms-challenge">
 
-        <table class="table table-bordered table-hover">
-            <tbody>
-            <tr>
-                <th scope="row">{{ 'gateway.form.gateway_send_sms_challenge.label.phone_number'|trans }}</th>
-                <td>{{ phoneNumber }}</td>
-            </tr>
-            </tbody>
-        </table>
-
         {{ form(form) }}
 
     </div>
 
+    <p>{{ 'gateway.second_factor.sms.text.next_step'|trans }}</p>
+
 {% endblock %}
+
+{% block footer %}
+    <ul class="nav nav-pills containing-cancel">
+        <li class="nav-item">
+            {{ form_start(cancelForm) }}
+            {{ form_widget(cancelForm.cancel, {}) }}
+            {{ form_end(cancelForm) }}
+        </li>
+        <li class="nav-item"><a href="{{ global_view_parameters.supportUrl }}" target="_blank">Help</a></li>
+    </ul>
+{% endblock footer %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifySmsSecondFactorChallenge.html.twig
@@ -1,19 +1,19 @@
-{% extends "::base.html.twig" %}
+{% extends "@SurfnetStepupGatewayGateway/SecondFactor/secondFactorAuthentication.html.twig" %}
 
-{% block page_title %}{{ 'gateway.second_factor.sms.verify_challenge.title.page'|trans }}{% endblock %}
-
+{% block application_name %}{{ 'gateway.second_factor.sms.verify_challenge.title.page'|trans }}{% endblock application_name %}
 {% block content %}
-    <h2>{{ block('page_title') }}</h2>
 
     <p>{{ 'gateway.second_factor.sms.text.help_user_enter_challenge'|trans }}</p>
 
-    <ol>
-        <li>{{ 'gateway.second_factor.sms.text.enter_challenge_below'|trans }}</li>
-        <li>{{ 'gateway.second_factor.sms.text.retry_if_not_received'|trans }}</li>
-    </ol>
-
-    <hr>
-
-    {{ form(form) }}
+    <div class="form-gateway-verify-sms-challenge">
+        {{ form_start(form) }}
+        {{ form_errors(form) }}
+        <div class="row">
+        {{ form_widget(form.challenge) }}
+        {{ form_widget(form.verify_challenge) }}
+        </div>
+        <p>{{ 'gateway.second_factor.sms.text.resend_challenge_text'|trans }} {{ form_widget(form.resend_challenge) }}
+        {{ form_end(form) }}
+    </div>
 
 {% endblock %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/verifyYubikeySecondFactor.html.twig
@@ -1,19 +1,10 @@
-{% extends "::base.html.twig" %}
+{% extends "@SurfnetStepupGatewayGateway/SecondFactor/secondFactorAuthentication.html.twig" %}
 
-{% block page_title %}{{ 'ra.registration.yubikey.title.enter_challenge'|trans }}{% endblock %}
+{% block application_name %}{{ 'ra.registration.yubikey.title.enter_challenge'|trans }}{% endblock application_name %}
 
 {% block content %}
-    <h2>{{ block('page_title') }}</h2>
 
-    <p>{{ 'gateway.second_factor.yubikey.text.help_user_enter_challenge'|trans }}</p>
-
-    <ol>
-        <li>{{ 'gateway.second_factor.yubikey.text.connect_yubikey_to_pc'|trans }}</li>
-        <li>{{ 'gateway.second_factor.yubikey.text.ensure_form_field_focus'|trans }}</li>
-        <li>{{ 'gateway.second_factor.yubikey.text.press_once_form_auto_submitted'|trans }}</li>
-    </ol>
-
-    <hr>
+    <p>{{ 'gateway.second_factor.yubikey.text.enter_challenge'|trans }}</p>
 
     {{ form_start(form) }}
     {{ form_errors(form) }}
@@ -21,5 +12,13 @@
     {{ form_row(form.otp, { value: '' }) }}
 
     {{ form_end(form) }}
+
+
+    <p>{{ 'gateway.second_factor.yubikey.text.help_user_enter_challenge'|trans }}</p>
+    <ol>
+        <li>{{ 'gateway.second_factor.yubikey.text.connect_yubikey_to_pc'|trans }}</li>
+        <li>{{ 'gateway.second_factor.yubikey.text.ensure_form_field_focus'|trans }}</li>
+        <li>{{ 'gateway.second_factor.yubikey.text.press_once_form_auto_submitted'|trans }}</li>
+    </ol>
 
 {% endblock %}


### PR DESCRIPTION
In these five commits the general OpenConext styling as seen in Engineblock is applied in StepUp. More importantly the authentication views have been revised to be more compact and contain less instructions for the end users. The design changes are based on the changes found on the [Surfnet wiki](https://wiki.surfnet.nl/display/coininfra/Nieuwe+schermen).

https://www.pivotaltracker.com/story/show/155856648