### PR TITLE
Allow unknown attributes to pass through Gateway

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -178,6 +178,8 @@ surfnet_stepup_gateway_second_factor_only:
 
 surfnet_saml:
     hosted:
+        attribute_dictionary:
+            ignore_unknown_attributes: true
         service_provider:
             enabled: true
             assertion_consumer_route: gateway_serviceprovider_consume_assertion


### PR DESCRIPTION
By upgrading the Steupup-saml-bundle to a version >2.10 we can enable the `ignore_unknown_attributes` feature for the gateway. Effectively fixing the bug 'described' in: 

https://www.pivotaltracker.com/story/show/156264642