### PR TITLE
Restyle error views

### DIFF
--- a/app/Resources/public/less/authentication.less
+++ b/app/Resources/public/less/authentication.less
@@ -1,24 +1,9 @@
-
 body.authentication {
-  background-color: @gray-lighter;
-  font-size: 15px;
-  line-height: 20px;
-
-  h1 {
-    font-size: 24px;
-    line-height: 26px;
-  }
 
   .container.authentication {
     background: #fff;
+    max-width: 75rem;
     padding: 0 2rem;
-
-    @media (min-width: @medium) {
-      border-radius: 4px;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, .2);
-      margin-top: 2rem;
-      max-width: 75rem;
-    }
   }
   .page-header {
     margin: 0;
@@ -27,22 +12,6 @@ body.authentication {
 
   .authentication-content {
     padding: 4rem;
-
-    @media (max-width: @small) {
-      padding: 2rem 0;
-    }
-  }
-
-  footer {
-    padding-bottom: 2rem;
-
-    form {
-      display: inline;
-
-      button {
-        padding: 0;
-      }
-    }
   }
 
   form[name="gateway_verify_yubikey_otp"] {

--- a/app/Resources/public/less/default.less
+++ b/app/Resources/public/less/default.less
@@ -2,20 +2,69 @@
 @FontAwesomePath: "/fonts";
 @fa-font-path: "/fonts";
 
-div.page-header {
-    img.logo {
-        max-width: 180px;
-        max-height: 90px;
+body {
+  background-color: @gray-lighter;
+  font-size: 15px;
+  line-height: 20px;
+
+  @media (max-width: @medium) {
+    background-color: white;
+  }
+
+  h1 {
+    font-size: 24px;
+    line-height: 26px;
+  }
+
+  .container {
+    max-width: 100rem;
+    background: #fff;
+    padding: 0 2rem;
+
+    @media (min-width: @medium) {
+      border-radius: 4px;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, .2);
+      margin-top: 2rem;
     }
+
+    .content {
+      @media (max-width: @small) {
+        padding: 2rem 0;
+      }
+    }
+  }
+
+  .page-header {
+    margin: 0 0 2rem 0;
+    padding: 2rem 0 1rem 0;
+  }
+
+  footer {
+    padding-bottom: 2rem;
+
+    form {
+      display: inline;
+
+      button {
+        padding: 0;
+      }
+    }
+  }
+}
+
+div.page-header {
+  img.logo {
+    max-width: 180px;
+    max-height: 90px;
+  }
 }
 
 .btn-off-screen {
-    position: absolute;
-    left: 100%;
+  position: absolute;
+  left: 100%;
 }
 
-
 div.middle {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/chooseSecondFactor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/chooseSecondFactor.html.twig
@@ -10,9 +10,9 @@
 
     {% for secondFactor in secondFactors %}
     <div class="row middle">
-        <div class="col-lg-1 col-sm-2 logo"><img src="{{ second_factor_logo(secondFactor.secondFactorType) }}"></div>
+        <div class="col-lg-2 col-sm-2 logo"><img src="{{ second_factor_logo(secondFactor.secondFactorType) }}"></div>
         <div class="col-lg-2 col-sm-2 col-xs-5 title">{{ secondFactor.secondFactorType|trans_second_factor_type }}</div>
-        <div class="col-lg-9 col-sm-8 col-xs-5">{{ form_widget(form.offsetGet('choose_' ~ secondFactor.secondFactorType)) }}</div>
+        <div class="col-lg-8 col-sm-8 col-xs-5">{{ form_widget(form.offsetGet('choose_' ~ secondFactor.secondFactorType)) }}</div>
     </div>
     {% endfor %}
 


### PR DESCRIPTION
The error views are now presented in the new OpenConext style. The solution was to update the default styling to this design.

This PR was created on top of the #144 feature.

https://www.pivotaltracker.com/story/show/156343095