### PR TITLE
Remove left over UL element

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/secondFactorAuthentication.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/SecondFactor/secondFactorAuthentication.html.twig
@@ -18,5 +18,4 @@
     {{ form_widget(cancelForm.cancel, {}) }}
     {{ form_end(cancelForm) }}
     <a class="pull-right" href="{{ global_view_parameters.supportUrl }}" target="_blank">Help</a>
-    </ul>
 {% endblock footer %}


### PR DESCRIPTION
In 8e39a9d the UL navbar styling was replaced by using styled links. The
closing UL tag was not removed. This commit fixes that.