### PR TITLE
Update stepup flow documentation

### DIFF
--- a/docs/GatewayState.md
+++ b/docs/GatewayState.md
@@ -245,6 +245,10 @@ deactivate SP
 
 ## Gateway GSSP verification flow
 
+This flow happens when a user is asked to verify his second factor token,
+the service provider in this diagram can be any (external) service provider,
+or SelfService when the "Test a token" button is used.
+
 ![flow](diagrams/gateway-state-gssp-verification-flow.png)
 <!---
 regenerate this diagram with `plantuml GatewayState.md` or with http://www.plantuml.com/plantuml
@@ -344,6 +348,9 @@ deactivate SP
 --->
 
 ## Gateway GSSP registration flow
+
+This flow happens when users register their token in SelfService and when this token is
+verified in RA. So the service provider in this diagram is always SelfService or RA.
 
 ![flow](diagrams/gateway-state-gssp-registration-flow.png)
 <!---

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
@@ -55,7 +55,8 @@ class SamlProxyController extends Controller
      * registration. Verification is not initiated with a SAML AUthnRequest,
      * see sendSecondFactorVerificationAuthnRequestAction().
      *
-     * The service provider in this context is SelfService.
+     * The service provider in this context is SelfService (when registering
+     * a token) or RA (when vetting a token).
      *
      * @param string  $provider
      * @param Request $httpRequest
@@ -192,7 +193,7 @@ class SamlProxyController extends Controller
      * The GSSP application sent an assertion back to the gateway. When
      * successful, the user is sent back to:
      *
-     *  1. in case of registration: back to the originating SP (SelfService)
+     *  1. in case of registration: back to the originating SP (SelfService or RA)
      *  2. in case of verification: internal redirect to SecondFactorController
      *
      * @param string  $provider


### PR DESCRIPTION
The documentation incorrectly stated the SamlProxyController was only
used as a full proxy (SSO+ACS) when registering a token in SS. The
documentation now reflects the following fact:

 * in case of registration (SS) or vetting (RA), the SP (SS/RA) sends
   a request directly to the SamlProxyController SSO endpoint

 * in all other situations (SS test button, external SP) the
   SamlProxyController SSO endpoint is not used, but the user is
   instead internally redirected from the regular GatewayController
   SSO endpoint