### PR TITLE
Use locale from cookie if no second factor is selected

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
@@ -152,6 +152,7 @@ services:
         arguments:
             - @gateway.proxy.response_context
             - @gateway.service.second_factor_service
+            - @surfnet_stepup.locale_cookie_helper
         tags: [{ name: kernel.event_subscriber }]
 
     gateway.locale_provider:


### PR DESCRIPTION
Gateway always used the locale of the second factor, but when showing
the token selection screen, there is no selected second factor
yet. This commit changes the behaviour so we fall back to the
stepup_locale cookie.

See https://www.pivotaltracker.com/story/show/156947307