### PR TITLE
Use assertion NotOnOrAfter for SubjectConfirmation validity

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
@@ -148,7 +148,7 @@ class ProxyResponseService
         $confirmationData                      = new SubjectConfirmationData();
         $confirmationData->InResponseTo        = $this->proxyStateHandler->getRequestId();
         $confirmationData->Recipient           = $destination;
-        $confirmationData->NotOnOrAfter        = $this->getTimestamp('PT8H');
+        $confirmationData->NotOnOrAfter        = $newAssertion->getNotOnOrAfter();
 
         $confirmation->SubjectConfirmationData = $confirmationData;
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/ProxyResponseServiceTest.php
@@ -210,4 +210,37 @@ final class ProxyResponseServiceTest extends PHPUnit_Framework_TestCase
 
         $factory->createProxyResponse($originalAssertion, 'https://acs');
     }
+
+    /**
+     * Limit SubjectConfirmationData validity to Assertion validity.
+     *
+     * See https://www.pivotaltracker.com/story/show/157880479
+     */
+    public function testSubjectConfirmationNotOnOrAfterEqualsAssertionNotOnOrAfter()
+    {
+        $factory = new ProxyResponseService(
+            $this->identityProvider,
+            $this->proxyStateHandler,
+            $this->assertionSigningService,
+            $this->attributeDictionary,
+            $this->attributeDefinition,
+            $this->loa
+        );
+
+        $originalAssertion = new Assertion();
+
+        $response = $factory->createProxyResponse($originalAssertion, 'https://acs');
+
+        $assertions = $response->getAssertions();
+
+        /** @var \SAML2\Assertion $assertion */
+        $assertion = reset($assertions);
+
+        $subjects = $assertion->getSubjectConfirmation();
+
+        /** @var \SAML2\XML\saml\SubjectConfirmation $subjectConfirmation */
+        $subjectConfirmation = reset($subjects);
+
+        $this->assertEquals($assertion->getNotOnOrAfter(), $subjectConfirmation->SubjectConfirmationData->NotOnOrAfter);
+    }
 }

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Saml/ProxyResponseFactory.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Saml/ProxyResponseFactory.php
@@ -112,7 +112,7 @@ class ProxyResponseFactory
         $confirmationData                      = new SubjectConfirmationData();
         $confirmationData->InResponseTo        = $this->stateHandler->getRequestId();
         $confirmationData->Recipient           = $destination;
-        $confirmationData->NotOnOrAfter        = $this->getTimestamp('PT8H');
+        $confirmationData->NotOnOrAfter        = $newAssertion->getNotOnOrAfter();
 
         $confirmation->SubjectConfirmationData = $confirmationData;
 

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Saml/ResponseFactory.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Saml/ResponseFactory.php
@@ -132,7 +132,7 @@ final class ResponseFactory
         $confirmationData                      = new SubjectConfirmationData();
         $confirmationData->InResponseTo        = $this->proxyStateHandler->getRequestId();
         $confirmationData->Recipient           = $destination;
-        $confirmationData->NotOnOrAfter        = $this->getTimestamp('PT8H');
+        $confirmationData->NotOnOrAfter        = $newAssertion->getNotOnOrAfter();
 
         $confirmation->SubjectConfirmationData = $confirmationData;
 


### PR DESCRIPTION
The SAML spec states the NotOnOrAfter of a subject confirmation should
not exceed the value of the assertions NotOnOrAfter. Gateway now uses
the assertion NotOnOrAfter value of SubjectConfirmation, instead of a
timestamp 8 hours in the future. The NotOnOrAfter is now always 5
minutes after generating the response.

See https://www.pivotaltracker.com/story/show/157880479