### PR TITLE
Provide a mock Yubikey service

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -1,5 +1,6 @@
 imports:
     - { resource: config_dev.yml }
+    - { resource: services_test.yml }
 
 framework:
     test: ~

--- a/app/config/services_test.yml
+++ b/app/config/services_test.yml
@@ -1,0 +1,6 @@
+
+# Use this service definition file to override services in the test environment. For example to mock certain services
+
+services:
+  surfnet_gateway_api.service.yubikey:
+    class: Surfnet\StepupGateway\ApiBundle\Tests\TestDouble\Service\YubikeyService

--- a/src/Surfnet/StepupGateway/ApiBundle/Dto/YubikeyOtpVerificationResult.php
+++ b/src/Surfnet/StepupGateway/ApiBundle/Dto/YubikeyOtpVerificationResult.php
@@ -16,8 +16,9 @@
  * limitations under the License.
  */
 
-namespace Surfnet\StepupGateway\GatewayBundle\Service\StepUp;
+namespace Surfnet\StepupGateway\ApiBundle\Dto;
 
+use DomainException;
 use Surfnet\StepupBundle\Value\YubikeyPublicId;
 
 class YubikeyOtpVerificationResult
@@ -40,7 +41,6 @@ class YubikeyOtpVerificationResult
      * @param int $result
      * @param YubikeyPublicId|null $publicId
      * @throws DomainException When $result is not one of the RESULT constants.
-     * @throws InvalidArgumentException When the public ID is not a string.
      */
     public function __construct($result, YubikeyPublicId $publicId = null)
     {

--- a/src/Surfnet/StepupGateway/ApiBundle/Service/YubikeyServiceInterface.php
+++ b/src/Surfnet/StepupGateway/ApiBundle/Service/YubikeyServiceInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\ApiBundle\Service;
+
+use Surfnet\StepupGateway\ApiBundle\Dto\Otp as OtpDto;
+use Surfnet\StepupGateway\ApiBundle\Dto\Requester;
+use Surfnet\StepupGateway\GatewayBundle\Service\StepUp\YubikeyOtpVerificationResult;
+
+interface YubikeyServiceInterface
+{
+    /**
+     * @param OtpDto $otp
+     * @param Requester $requester
+     * @param string $secondFactorIdentifier
+     * @return YubikeyOtpVerificationResult
+     */
+    public function verify(OtpDto $otp, Requester $requester, $secondFactorIdentifier);
+}

--- a/src/Surfnet/StepupGateway/ApiBundle/Tests/TestDouble/Service/YubikeyService.php
+++ b/src/Surfnet/StepupGateway/ApiBundle/Tests/TestDouble/Service/YubikeyService.php
@@ -21,8 +21,8 @@ namespace Surfnet\StepupGateway\ApiBundle\Tests\TestDouble\Service;
 use Surfnet\StepupBundle\Value\YubikeyPublicId;
 use Surfnet\StepupGateway\ApiBundle\Dto\Otp as OtpDto;
 use Surfnet\StepupGateway\ApiBundle\Dto\Requester;
+use Surfnet\StepupGateway\ApiBundle\Dto\YubikeyOtpVerificationResult;
 use Surfnet\StepupGateway\ApiBundle\Service\YubikeyServiceInterface;
-use Surfnet\StepupGateway\GatewayBundle\Service\StepUp\YubikeyOtpVerificationResult;
 
 /**
  * Serves a test double for : ApiBundle/Service/YubikeyService

--- a/src/Surfnet/StepupGateway/ApiBundle/Tests/TestDouble/Service/YubikeyService.php
+++ b/src/Surfnet/StepupGateway/ApiBundle/Tests/TestDouble/Service/YubikeyService.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\ApiBundle\Tests\TestDouble\Service;
+
+use Surfnet\StepupBundle\Value\YubikeyPublicId;
+use Surfnet\StepupGateway\ApiBundle\Dto\Otp as OtpDto;
+use Surfnet\StepupGateway\ApiBundle\Dto\Requester;
+use Surfnet\StepupGateway\ApiBundle\Service\YubikeyServiceInterface;
+use Surfnet\StepupGateway\GatewayBundle\Service\StepUp\YubikeyOtpVerificationResult;
+
+/**
+ * Serves a test double for : ApiBundle/Service/YubikeyService
+ *
+ * This service will accept any OtpDto that it is fed, always returning a OtpVerificationResult with status STATUS_OK
+ */
+class YubikeyService implements YubikeyServiceInterface
+{
+    /**
+     * @param OtpDto $otp
+     * @param Requester $requester
+     * @param Requester $secondFactorIdentifier
+     * @return YubikeyOtpVerificationResult
+     */
+    public function verify(OtpDto $otp, Requester $requester, $secondFactorIdentifier)
+    {
+        return new YubikeyOtpVerificationResult(
+            YubikeyOtpVerificationResult::RESULT_PUBLIC_ID_MATCHED,
+            new YubikeyPublicId('12341234')
+        );
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/StepUpAuthenticationServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/StepUpAuthenticationServiceTest.php
@@ -26,9 +26,8 @@ use Surfnet\StepupBundle\Service\LoaResolutionService;
 use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Service\SmsSecondFactorService;
 use Surfnet\StepupBundle\Value\Loa;
-use Surfnet\StepupGateway\ApiBundle\Service\YubikeyService;
+use Surfnet\StepupGateway\ApiBundle\Service\YubikeyServiceInterface;
 use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactorRepository;
-use Surfnet\StepupGateway\GatewayBundle\Exception\InvalidStepupShoFormatException;
 use Surfnet\StepupGateway\GatewayBundle\Exception\LoaCannotBeGivenException;
 use Surfnet\StepupGateway\GatewayBundle\Service\StepUpAuthenticationService;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -65,7 +64,7 @@ final class StepUpAuthenticationServiceTest extends PHPUnit_Framework_TestCase
             new Loa(3,'https://gw-dev.stepup.coin.surf.net/authentication/loa3'),
         ]);
         $this->secondFactorRepository = m::mock(SecondFactorRepository::class);
-        $this->yubikeyService = m::mock(YubikeyService::class);
+        $this->yubikeyService = m::mock(YubikeyServiceInterface::class);
         $this->smsSfService = m::mock(SmsSecondFactorService::class);
         $this->translator = m::mock(TranslatorInterface::class);
         $this->logger = m::mock(LoggerInterface::class);


### PR DESCRIPTION
:warning:  **Note that** This PR is an extension of #164 

This PR provides a very dump test double for the YubikeyService in the ApiBundle.

Refactoring of the AuthenticationService in the GatewayBundle was required to be able to build the mock.
Some of the application logic was moved to the API, this to be able to mock the Api service. In essence the YubikeyOtpVerificationResult was moved to the API, becoming the return type for said service.

The verification logic that was performed in the Gateway bundle was moved to the ApiBundle.

This was the most elegant way to then provide a test double. An alternative was to also provide a test double for the StepUpAuthenticationService, which is a very godlike service which would result in losing too much important business logic for the E2E tests.