### PR TITLE
Remove incorrect third parameter from render call

### DIFF
--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
@@ -235,8 +235,7 @@ class SamlProxyController extends Controller
 
         $response = parent::render(
             'SurfnetStepupGatewaySamlStepupProviderBundle:SamlProxy:' . $view . '.html.twig',
-            $parameters,
-            $response
+            $parameters
         );
 
         // clear the state so we can call again :)


### PR DESCRIPTION
SamlProxyController was recently refactored by both @pablothedude  and myself. During refactoring we tried to keep a good eye on any regressions. One slipped our attention. To prevent the overloading of the now finalized `ControllerTrait::render` method, I removed the override and called the parent method directly. In this, adding an extra, not required and wrong third parameter.

The third parameter should not be added to the render method, called on the parent. This third parameter can hold a http response and should not be loaded with the SAML Response.

This was incorrectly refactored for Symfony 3.4 support in: https://github.com/OpenConext/Stepup-Gateway/commit/4928594581a818cf75766eccd9136fe86c45608b