### PR TITLE
Adjust test config to allow smoke testing

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -72,14 +72,8 @@ doctrine:
                 password: "%database_deploy_password%"
                 charset:  UTF8
 
+# The SP and IdP certificates are overloaded in 'services_test.yml'
 surfnet_saml:
-    hosted:
-        identity_provider:
-            public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
-            private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
-        metadata:
-            public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
-            private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
     remote:
         identity_provider:
             certificate: MIIC6jCCAdICCQC9cRx5wiwWOjANBgkqhkiG9w0BAQsFADA3MRwwGgYDVQQDDBNTZWxmU2VydmljZSBTQU1MIFNQMRcwFQYDVQQKDA5EZXZlbG9wbWVudCBWTTAeFw0xODA3MzAxMjMwNDdaFw0yMzA3MjkxMjMwNDdaMDcxHDAaBgNVBAMME1NlbGZTZXJ2aWNlIFNBTUwgU1AxFzAVBgNVBAoMDkRldmVsb3BtZW50IFZNMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhbI0Xy682DuvWchg6FYnI+DNwLXef2XExM4YVRBaMMsOZ3rBtQUTMSqYan6SK/BOEXLs0rNiJjyM0dn+F98wg3fv5zIADlvfk3LBVdcGsrpVfFUWtSa73yMgbROy8/RJADbUJE/HUB3ZmdjdiuD2Cui2aoWwT2HR8ukJwmoxiu45IWFPbqPQ7/1mH644JPOWTPLTv4OGGLQo8MNrP1oRCiZ0IEL4CQeGOOju5rfIJ0bTVm0UmelT4hGaqZovBMwXp3QV41akJ7UEMEBK2YMnLQy47Xuzi7aTDhJlvHcJ8mfH2NbjRh7hJoACVRTvQloxajgkr1iGMiWiiqT0e+YYwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBwZ0gRHvR8B8KivrXrhWNL9uLvWhEAH7OiDqo+fywkBp5KEuDJcbbvEPftHunSAGylg7M2xKuBIGamFpp74WDJccrtZ1jJ4qqnacUDRQrTLqqMZKqGpFOU0xjKkSxSGRuMtGN9/7er/TeonjQ0XBvjYvTomy3b5aCLVWRvEfKu2g1sDd8uhr62RY/HfMgidEt7LHDolkCVg+6JzY3OTcgeHga3cvYObOYPplxw1YPq5+BqqxaUW4nfb5DtK33bZBYMeyV6BZtSggc5Z/19aPx/s0bf6ySTUyB3lRqe5d3etCns4bGidORCl/6EZiXwVcPvmYmxYXqmuNWfps7isUvo

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -44,3 +44,14 @@ doctrine:
                 password: "%database_deploy_password%"
                 charset:  UTF8
 
+surfnet_saml:
+    hosted:
+        identity_provider:
+            public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
+            private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
+        metadata:
+            public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
+            private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
+    remote:
+        identity_provider:
+            certificate: MIIC6jCCAdICCQC9cRx5wiwWOjANBgkqhkiG9w0BAQsFADA3MRwwGgYDVQQDDBNTZWxmU2VydmljZSBTQU1MIFNQMRcwFQYDVQQKDA5EZXZlbG9wbWVudCBWTTAeFw0xODA3MzAxMjMwNDdaFw0yMzA3MjkxMjMwNDdaMDcxHDAaBgNVBAMME1NlbGZTZXJ2aWNlIFNBTUwgU1AxFzAVBgNVBAoMDkRldmVsb3BtZW50IFZNMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhbI0Xy682DuvWchg6FYnI+DNwLXef2XExM4YVRBaMMsOZ3rBtQUTMSqYan6SK/BOEXLs0rNiJjyM0dn+F98wg3fv5zIADlvfk3LBVdcGsrpVfFUWtSa73yMgbROy8/RJADbUJE/HUB3ZmdjdiuD2Cui2aoWwT2HR8ukJwmoxiu45IWFPbqPQ7/1mH644JPOWTPLTv4OGGLQo8MNrP1oRCiZ0IEL4CQeGOOju5rfIJ0bTVm0UmelT4hGaqZovBMwXp3QV41akJ7UEMEBK2YMnLQy47Xuzi7aTDhJlvHcJ8mfH2NbjRh7hJoACVRTvQloxajgkr1iGMiWiiqT0e+YYwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBwZ0gRHvR8B8KivrXrhWNL9uLvWhEAH7OiDqo+fywkBp5KEuDJcbbvEPftHunSAGylg7M2xKuBIGamFpp74WDJccrtZ1jJ4qqnacUDRQrTLqqMZKqGpFOU0xjKkSxSGRuMtGN9/7er/TeonjQ0XBvjYvTomy3b5aCLVWRvEfKu2g1sDd8uhr62RY/HfMgidEt7LHDolkCVg+6JzY3OTcgeHga3cvYObOYPplxw1YPq5+BqqxaUW4nfb5DtK33bZBYMeyV6BZtSggc5Z/19aPx/s0bf6ySTUyB3lRqe5d3etCns4bGidORCl/6EZiXwVcPvmYmxYXqmuNWfps7isUvo

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -15,6 +15,34 @@ nelmio_security:
         script: [ self, unsafe-inline ]
         style: [ self, unsafe-inline ]
 
+monolog:
+    channels: [authentication]
+    handlers:
+        prod-signaler:
+            type: fingers_crossed
+            action_level: ERROR
+            passthru_level: DEBUG # DEV setting: this means that all message of level DEBUG or higher are always logged
+            handler: main_syslog
+            bubble: true
+            channels: ["!authentication"] # the auth channel is logged by the next handler
+        main_syslog:
+            type: syslog
+            ident: stepup-gateway
+            facility: user
+            formatter: surfnet_stepup.monolog.json_formatter
+        authenthentication_syslog:
+            type: syslog
+            ident: stepup-authentication
+            facility: user
+            level: INFO
+            channels: [authentication]
+            formatter: gateway.monolog.gelf_to_string_formatter
+        main_logfile:
+            type: stream
+            handler: logfile
+            level: NOTICE
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+
 doctrine:
     dbal:
         default_connection: gateway

--- a/app/config/services_test.yml
+++ b/app/config/services_test.yml
@@ -1,5 +1,12 @@
-
 # Use this service definition file to override services in the test environment. For example to mock certain services
+
+parameters:
+  saml_metadata_publickey: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
+  saml_metadata_privatekey: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
+  saml_sp_publickey: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
+  saml_sp_privatekey: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
+  saml_idp_publickey: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
+  saml_idp_privatekey: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
 
 services:
   surfnet_gateway_api.service.yubikey:


### PR DESCRIPTION
Test certificates have been put in place in test mode and logging was re-enabled.