### PR TITLE
Fix sms challenge form

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/AnchorType.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/AnchorType.php
@@ -46,9 +46,7 @@ class AnchorType extends AbstractType implements ButtonTypeInterface
 
         $resolver->setRequired(['route']);
 
-        $resolver->setAllowedTypes([
-            'route' => 'string',
-        ]);
+        $resolver->setAllowedTypes('route', 'string');
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)

--- a/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifySmsChallengeType.php
@@ -40,7 +40,7 @@ class VerifySmsChallengeType extends AbstractType
             'label' => 'gateway.form.verify_sms_challenge.button.verify_challenge',
             'attr'  => ['class' => 'btn btn-primary'],
         ]);
-        $builder->add('resend_challenge', 'anchor', [
+        $builder->add('resend_challenge', AnchorType::class, [
             'label' => 'gateway.form.verify_sms_challenge.button.resend_challenge',
             'attr'  => ['class' => 'btn btn-link'],
             'route' => 'gateway_verify_second_factor_sms',


### PR DESCRIPTION
The sms-challenge form had a bug which resulted in an error because
the required form element could not be loaded. By using the FQDN this
should be fixed.