### PR TITLE
Improve AuthNFailed GW response handling

### DIFF
--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
@@ -141,7 +141,8 @@ class SamlProxyController extends Controller
         } catch (ResponseFailureException $e) {
             $response = $this->createResponseFailureResponse(
                 $provider,
-                $this->getDestination($provider->getStateHandler())
+                $this->getDestination($provider->getStateHandler()),
+                $e->getMessage()
             );
             return $this->renderSamlResponse('consumeAssertion', $provider->getStateHandler(), $response);
 
@@ -261,10 +262,14 @@ class SamlProxyController extends Controller
      * @param string $destination
      * @return SAMLResponse
      */
-    private function createResponseFailureResponse(Provider $provider, $destination)
+    private function createResponseFailureResponse(Provider $provider, $destination, $message)
     {
         $response = $this->createResponse($provider, $destination);
-        $response->setStatus(['Code' => Constants::STATUS_RESPONDER]);
+        $response->setStatus([
+            'Code' => Constants::STATUS_RESPONDER,
+            'SubCode' => Constants::STATUS_AUTHN_FAILED,
+            'Message' => $message
+        ]);
 
         return $response;
     }

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
@@ -23,6 +23,7 @@ use Exception;
 use SAML2\Constants;
 use SAML2\Response as SAMLResponse;
 use Surfnet\SamlBundle\Http\XMLResponse;
+use Surfnet\StepupGateway\GatewayBundle\Controller\GatewayController;
 use Surfnet\StepupGateway\GatewayBundle\Exception\ResponseFailureException;
 use Surfnet\StepupGateway\SamlStepupProviderBundle\Exception\InvalidSubjectException;
 use Surfnet\StepupGateway\SamlStepupProviderBundle\Exception\NotConnectedServiceProviderException;
@@ -302,9 +303,11 @@ class SamlProxyController extends Controller
      */
     private function createResponse(Provider $provider, $destination)
     {
+        $context = $this->getResponseContext();
+
         $response = new SAMLResponse();
         $response->setDestination($destination);
-        $response->setIssuer($provider->getIdentityProvider()->getEntityId());
+        $response->setIssuer($context->getIssuer());
         $response->setIssueInstant((new DateTime('now'))->getTimestamp());
         $response->setInResponseTo($provider->getStateHandler()->getRequestId());
 
@@ -355,5 +358,21 @@ class SamlProxyController extends Controller
     private function getProxyResponseFactory(Provider $provider)
     {
         return $this->get('gssp.provider.' . $provider->getName() . '.response_proxy');
+    }
+
+    /**
+     * @return \Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext
+     */
+    public function getResponseContext()
+    {
+        $stateHandler = $this->get('gateway.proxy.state_handler');
+
+        $responseContextServiceId = $stateHandler->getResponseContextServiceId();
+
+        if (!$responseContextServiceId) {
+            return $this->get(GatewayController::RESPONSE_CONTEXT_SERVICE_ID);
+        }
+
+        return $this->get($responseContextServiceId);
     }
 }


### PR DESCRIPTION
The GW proxy controller now also returns the subcode and error message
when one of the GSSP returned a failed response.

The exception message that was thrown while processing the SAMLResponse
is set as the message yielding something like:

"Could not process received Response, error: "Cannot process response,
preconditions not met: "Responder/AuthnFailed User canceled the
request""

This is far from perfect, preferably we'd simply set the original
"User canceled the request" message, this would entail quite some
rework to the gateway.

https://www.pivotaltracker.com/story/show/164657123