### PR TITLE
Test php 7.3 with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ sudo: false
 
 php:
   - 5.6
+  - 7.2
   - 7.3
 
 matrix:
   allow_failures:
+    - php: 7.2
     - php: 7.3
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ sudo: false
 
 php:
   - 5.6
-  - 7.0
+  - 7.3
 
 matrix:
   allow_failures:
-    - php: 7.0
+    - php: 7.3
 
 env:
   global:


### PR DESCRIPTION
This is done in order to be able to test behavior on php 7.3 to
explore possible php migration issues.