### PR TITLE
Use correct ResponseContext service identifier

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -261,11 +261,15 @@ class SecondFactorController extends Controller
             ));
         }
 
+        // Also send the response context service id, as later we need to know if this is regular SSO or SFO authn.
+        $responseContextServiceId = $context->getResponseContextServiceId();
+
         return $this->forward(
             'SurfnetStepupGatewaySamlStepupProviderBundle:SamlProxy:sendSecondFactorVerificationAuthnRequest',
             [
                 'provider' => $secondFactor->secondFactorType,
-                'subjectNameId' => $secondFactor->secondFactorIdentifier
+                'subjectNameId' => $secondFactor->secondFactorIdentifier,
+                'responseContextServiceId' => $responseContextServiceId,
             ]
         );
     }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
@@ -302,4 +302,17 @@ class ResponseContext
         $this->stateHandler->setSelectedSecondFactorId(null);
         $this->stateHandler->setSecondFactorVerified(false);
     }
+
+    /**
+     * Retrieve the ResponseContextServiceId from state
+     *
+     * Used to determine we are dealing with a SFO or regular authentication. Both have different ResponseContext
+     * instances, and it's imperative that successive consumers use the correct service.
+     *
+     * @return string|null
+     */
+    public function getResponseContextServiceId()
+    {
+        return $this->stateHandler->getResponseContextServiceId();
+    }
 }

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
@@ -63,7 +63,7 @@ class SamlProxyController extends Controller
      * The service provider in this context is SelfService (when registering
      * a token) or RA (when vetting a token).
      *
-     * @param string  $provider
+     * @param string $provider
      * @param Request $httpRequest
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
@@ -98,17 +98,22 @@ class SamlProxyController extends Controller
      * directly to the remote GSSP SSO URL, and the response is handled in
      * consumeAssertionAction().
      *
-     * @param $provider
-     * @param $subjectNameId
+     * @param string $provider
+     * @param string $subjectNameId
+     * @param string $responseContextServiceId
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function sendSecondFactorVerificationAuthnRequestAction($provider, $subjectNameId)
+    public function sendSecondFactorVerificationAuthnRequestAction($provider, $subjectNameId, $responseContextServiceId)
     {
         $provider = $this->getProvider($provider);
 
         $gsspSecondFactorVerificationService = $this->getGsspSecondFactorVerificationService();
 
-        $authnRequest = $gsspSecondFactorVerificationService->sendSecondFactorVerificationAuthnRequest($provider, $subjectNameId);
+        $authnRequest = $gsspSecondFactorVerificationService->sendSecondFactorVerificationAuthnRequest(
+            $provider,
+            $subjectNameId,
+            $responseContextServiceId
+        );
 
         /** @var \Surfnet\SamlBundle\Http\RedirectBinding $redirectBinding */
         $redirectBinding = $this->get('surfnet_saml.http.redirect_binding');
@@ -204,8 +209,10 @@ class SamlProxyController extends Controller
     private function getDestination(StateHandler $stateHandler)
     {
         if ($stateHandler->secondFactorVerificationRequested()) {
+            // This can either be a SFO or 'regular' SSO authentication. Both use a ResponseContext service of their own
+            $responseContextServiceId = $stateHandler->getResponseContextServiceId();
             // GSSP verification action, return to SP from GatewayController state!
-            $destination = $this->get('gateway.proxy.response_context')->getDestination();
+            $destination = $this->get($responseContextServiceId)->getDestination();
         } else {
             // GSSP registration action, return to SP remembered in ssoAction().
             $serviceProvider = $this->getServiceProvider(
@@ -222,17 +229,17 @@ class SamlProxyController extends Controller
     }
 
     /**
-     * @param string         $view
-     * @param StateHandler   $stateHandler
+     * @param string $view
+     * @param StateHandler $stateHandler
      * @param SAMLResponse $response
      * @return Response
      */
     public function renderSamlResponse($view, StateHandler $stateHandler, SAMLResponse $response)
     {
         $parameters = [
-            'acu'        => $response->getDestination(),
-            'response'   => $this->getResponseAsXML($response),
-            'relayState' => $stateHandler->getRelayState()
+            'acu' => $response->getDestination(),
+            'response' => $this->getResponseAsXML($response),
+            'relayState' => $stateHandler->getRelayState(),
         ];
 
         $response = parent::render(
@@ -286,10 +293,12 @@ class SamlProxyController extends Controller
     private function createAuthnFailedResponse(Provider $provider, $destination)
     {
         $response = $this->createResponse($provider, $destination);
-        $response->setStatus([
-            'Code'    => Constants::STATUS_RESPONDER,
-            'SubCode' => Constants::STATUS_AUTHN_FAILED
-        ]);
+        $response->setStatus(
+            [
+                'Code' => Constants::STATUS_RESPONDER,
+                'SubCode' => Constants::STATUS_AUTHN_FAILED,
+            ]
+        );
 
         return $response;
     }

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Service/Gateway/SecondFactorVerificationService.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Service/Gateway/SecondFactorVerificationService.php
@@ -38,10 +38,15 @@ class SecondFactorVerificationService
      *
      * @param Provider $provider
      * @param string $subjectNameId
+     * @param string $responseContextServiceId
+     *
      * @return AuthnRequest
      */
-    public function sendSecondFactorVerificationAuthnRequest(Provider $provider, $subjectNameId)
-    {
+    public function sendSecondFactorVerificationAuthnRequest(
+        Provider $provider,
+        $subjectNameId,
+        $responseContextServiceId
+    ) {
         $stateHandler = $provider->getStateHandler();
 
         $originalRequestId = $this->responseContext->getInResponseTo();
@@ -56,6 +61,7 @@ class SecondFactorVerificationService
             ->setRequestId($originalRequestId)
             ->setGatewayRequestId($authnRequest->getRequestId())
             ->setSubject($subjectNameId)
+            ->setResponseContextServiceId($responseContextServiceId)
             ->markRequestAsSecondFactorVerification();
 
         /** @var \Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger $logger */

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Tests/Service/Gateway/SecondFactorVerificationServiceTest.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Tests/Service/Gateway/SecondFactorVerificationServiceTest.php
@@ -1,5 +1,19 @@
 <?php
-
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace Surfnet\StepupGateway\SamlStepupProviderBundle\Tests\Service\Gateway;
 
@@ -96,7 +110,11 @@ class SecondFactorVerificationServiceTest extends GatewaySamlTestCase
         ]);
 
         // Handle request
-        $authnRequest = $this->samlProxySecondFactorService->sendSecondFactorVerificationAuthnRequest($this->provider, $subjectNameId);
+        $authnRequest = $this->samlProxySecondFactorService->sendSecondFactorVerificationAuthnRequest(
+            $this->provider,
+            $subjectNameId,
+            'service_id'
+        );
 
         // Assert authnRequest
         $this->assertInstanceOf(AuthnRequest::class, $authnRequest);
@@ -129,6 +147,7 @@ class SecondFactorVerificationServiceTest extends GatewaySamlTestCase
                 'relay_state' => '',
                 'gateway_request_id' => '_mocked_generated_id',
                 'subject' => 'test-gssp-id',
+                'response_context_service_id' => 'service_id',
                 'is_second_factor_verification' => true,
             ],
         ], $this->getSessionData('attributes'));


### PR DESCRIPTION
Between regular SSO and SFO authentication, different response context
objects are used. It is very important that the correct one is used
(retrieved from container) during the ACS step. This was not the case
when dealing with SFO responses. In this commit, that is solved.

The problem is described in greater detail in the bug report:
https://www.pivotaltracker.com/story/show/168746898