### PR TITLE
Install ant on Travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,8 @@ branches:
   only:
     - master
     - develop
-    - release/2.8
+
+addons:
+  apt:
+    packages:
+      - ant


### PR DESCRIPTION
Ant is no longer part of the Travis Xenial image as noted in: 

https://travis-ci.community/t/ant-not-available-by-default-for-java-projects-on-xenial/4468