### PR TITLE
Upgrade Stepup-saml-bundle to version 4.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.10.5
+This is a security release that will harden the application against CVE 2019-346
+ * Upgrade Stepup-saml-bundle to version 4.1.8 #185
+
 ## 2.10.4
 **Improvements**
 * Install security upgrades

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "0353e9765be2fa8d8d09b16b88a6d138",
@@ -2314,23 +2314,21 @@
         },
         {
             "name": "robrichards/xmlseclibs",
-            "version": "3.0.1",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robrichards/xmlseclibs.git",
-                "reference": "d937712f70f93a584eb0299ccd87dc6374003781"
+                "reference": "0a53d3c3aa87564910cae4ed01416441d3ae0db5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/d937712f70f93a584eb0299ccd87dc6374003781",
-                "reference": "d937712f70f93a584eb0299ccd87dc6374003781",
+                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/0a53d3c3aa87564910cae4ed01416441d3ae0db5",
+                "reference": "0a53d3c3aa87564910cae4ed01416441d3ae0db5",
                 "shasum": ""
             },
             "require": {
+                "ext-openssl": "*",
                 "php": ">= 5.4"
-            },
-            "suggest": {
-                "ext-openssl": "OpenSSL extension"
             },
             "type": "library",
             "autoload": {
@@ -2350,7 +2348,7 @@
                 "xml",
                 "xmldsig"
             ],
-            "time": "2017-08-31T09:27:07+00:00"
+            "time": "2019-11-05T11:44:22+00:00"
         },
         {
             "name": "sensio/distribution-bundle",
@@ -2628,16 +2626,16 @@
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-bundle.git",
-                "reference": "5946dde19d5e095a5836d602b7abfa64cb71d6f1"
+                "reference": "3329ca027f57208d7a20882707ef4a01dd2a4fb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/5946dde19d5e095a5836d602b7abfa64cb71d6f1",
-                "reference": "5946dde19d5e095a5836d602b7abfa64cb71d6f1",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/3329ca027f57208d7a20882707ef4a01dd2a4fb6",
+                "reference": "3329ca027f57208d7a20882707ef4a01dd2a4fb6",
                 "shasum": ""
             },
             "require": {
@@ -2680,26 +2678,26 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2018-09-06T12:43:15+00:00"
+            "time": "2018-09-13T14:13:26+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",
-            "version": "4.1.4",
+            "version": "4.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-saml-bundle.git",
-                "reference": "bcac100da97865c30e8e079bf824b5e4452a268d"
+                "reference": "cf88eb328a31d30a3b94deea7931a759bd362aab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/bcac100da97865c30e8e079bf824b5e4452a268d",
-                "reference": "bcac100da97865c30e8e079bf824b5e4452a268d",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/cf88eb328a31d30a3b94deea7931a759bd362aab",
+                "reference": "cf88eb328a31d30a3b94deea7931a759bd362aab",
                 "shasum": ""
             },
             "require": {
                 "ext-openssl": "*",
                 "php": ">=5.6,<8.0-dev",
-                "robrichards/xmlseclibs": "^3.0",
+                "robrichards/xmlseclibs": "^3.0.4",
                 "simplesamlphp/saml2": "3.2.*",
                 "symfony/dependency-injection": ">=2.7,<4",
                 "symfony/framework-bundle": ">=2.7,<4"
@@ -2732,7 +2730,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2019-05-28T08:15:22+00:00"
+            "time": "2019-11-06T13:09:53+00:00"
         },
         {
             "name": "surfnet/stepup-u2f-bundle",
@@ -4942,6 +4940,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
         {


### PR DESCRIPTION
This change will apply the countermeasures to harden against
CVE 2019-3465 and will effectively bump `robrichards/xmlseclibs` to
version 3.0.4