### PR TITLE
Upgrade Node to version 10

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -60,4 +60,3 @@ jobs:
               if: failure()
               run:  |
                   cd ci/docker && docker-compose -f docker-compose-php74.yml exec -T php-fpm.stepup.example.com cat app/logs/webtest.log
-

--- a/app/config/config_webtest.yml
+++ b/app/config/config_webtest.yml
@@ -18,7 +18,7 @@ assetic:
     filters:
         less:
             node: "/usr/bin/node"
-            node_paths: ["/usr/local/lib/node_modules"]
+            node_paths: ["/usr/lib/node_modules/"]
             apply_to: '\.less$'
 
 nelmio_security:

--- a/ci/docker/php-fpm/Dockerfile-php72
+++ b/ci/docker/php-fpm/Dockerfile-php72
@@ -6,11 +6,10 @@ COPY docker/php-fpm/app.ini /usr/local/etc/php/conf.d/
 COPY app.php ../web/app.php
 
 # Install dependencies
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update && apt-get install -y \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get update && apt-get install -yf \
     git \
     nodejs \
-    npm \
     zip \
     chromium \
     libpng-dev \

--- a/ci/docker/php-fpm/Dockerfile-php74
+++ b/ci/docker/php-fpm/Dockerfile-php74
@@ -6,11 +6,10 @@ COPY docker/php-fpm/app.ini /usr/local/etc/php/conf.d/
 COPY app.php ../web/app.php
 
 # Install dependencies
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update && apt-get install -y \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get update && apt-get install -yf \
     git \
     nodejs \
-    npm \
     zip \
     chromium \
     libpng-dev \


### PR DESCRIPTION
LTS version 8 is no longer supported. Upgrading to version 10 (also lts)
is what the node team advises.

See task in: https://www.pivotaltracker.com/story/show/172199408