### PR TITLE
Make Metadata Factory publicly available

### DIFF
--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/DependencyInjection/SurfnetStepupGatewaySamlStepupProviderExtension.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/DependencyInjection/SurfnetStepupGatewaySamlStepupProviderExtension.php
@@ -236,6 +236,7 @@ class SurfnetStepupGatewaySamlStepupProviderExtension extends Extension
             new Reference('surfnet_saml.signing_service'),
             new Reference('gssp.provider.' . $provider . 'metadata.configuration')
         ]);
+        $metadataFactory->setPublic(true);
         $container->setDefinition('gssp.provider.' . $provider . '.metadata.factory', $metadataFactory);
     }
 


### PR DESCRIPTION
The metadata controller grabs this service from the service container
not utilizing DI. That results in a critical error, as this is no longer
allowed in Symfony 4. As it was deprecated in version 3.