### PR TITLE
Display custom form errors

### DIFF
--- a/public/scss/authentication.scss
+++ b/public/scss/authentication.scss
@@ -57,4 +57,12 @@ body.authentication {
   form[name="gateway_cancel_second_factor_verification"] {
     text-align: center;
   }
+
+  .form-error {
+    background: $pink-lighter;
+    border: 1px solid red;
+    border-radius: 5px;
+    margin-bottom: 1em;
+    padding: .5em;
+  }
 }

--- a/public/scss/vars.scss
+++ b/public/scss/vars.scss
@@ -3,3 +3,4 @@ $medium: 800px;
 $large: 1200px;
 
 $gray-lighter: #eeeeee;
+$pink-lighter: #ffeeee;

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/choose_second_factor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/choose_second_factor.html.twig
@@ -8,7 +8,12 @@
     <h2>{{ block('page_title') }}</h2>
     {{ form_start(form, {'attr': {'class': 'form-horizontal choose-second-factor-type'}}) }}
 
-    {{ form_errors(form) }}
+    {% set formErrors = form.vars.errors.form.getErrors(true) %}
+    {% if formErrors|length %}
+        {% for error in formErrors %}
+            <p class="form-error">{{ error.message }}</p>
+        {% endfor %}
+    {% endif %}
 
     {% for secondFactor in secondFactors %}
         <div class="row middle">

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/verify_sms_second_factor_challenge.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/verify_sms_second_factor_challenge.html.twig
@@ -7,7 +7,14 @@
 
     <div class="form-gateway-verify-sms-challenge">
         {{ form_start(form) }}
-        {{ form_errors(form) }}
+
+        {% set formErrors = form.vars.errors.form.getErrors(true) %}
+        {% if formErrors|length %}
+            {% for error in formErrors %}
+                <p class="form-error">{{ error.message }}</p>
+            {% endfor %}
+        {% endif %}
+
         <div class="row">
         {{ form_widget(form.challenge) }}
         {{ form_widget(form.verify_challenge) }}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/verify_yubikey_second_factor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/verify_yubikey_second_factor.html.twig
@@ -7,7 +7,13 @@
     <p>{{ 'gateway.second_factor.yubikey.text.enter_challenge'|trans }}</p>
 
     {{ form_start(form) }}
-    {{ form_errors(form) }}
+
+    {% set formErrors = form.vars.errors.form.getErrors(true) %}
+    {% if formErrors|length %}
+        {% for error in formErrors %}
+            <p class="form-error">{{ error.message }}</p>
+        {% endfor %}
+    {% endif %}
 
     {{ form_row(form.otp, { value: '' }) }}
 


### PR DESCRIPTION
As of Symfony 4, the form errors are not rendered when added with the addForm method on the form. They are to be retrieved by hand. And that was implemented for the forms where this ancient practice is used.

https://www.pivotaltracker.com/story/show/177722061