### PR TITLE
Use internal-collabPersonId when present

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
@@ -81,7 +81,7 @@ services:
             - "@gateway.proxy.sso.state_handler"
             - "@gateway.service.assertion_signing"
             - "@surfnet_saml.saml.attribute_dictionary"
-            - "@saml.attribute.eduPersonTargetedID"
+            - "@saml.attribute.internalCollabPersonId"
             - "@gateway.security.intrinsic_loa"
 
     gateway.security.intrinsic_loa:

--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
@@ -24,6 +24,7 @@ use DateTimeZone;
 use SAML2\Assertion;
 use SAML2\Constants;
 use SAML2\Response;
+use SAML2\XML\saml\NameID;
 use SAML2\XML\saml\SubjectConfirmation;
 use SAML2\XML\saml\SubjectConfirmationData;
 use Surfnet\SamlBundle\Entity\IdentityProvider;
@@ -55,6 +56,11 @@ class ProxyResponseService
     private $attributeDictionary;
 
     /**
+     * @var \Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
+     */
+    private $internalCollabPersonIdAttribute;
+
+    /**
      * @var \DateTime
      */
     private $currentTime;
@@ -70,19 +76,21 @@ class ProxyResponseService
     private $intrinsicLoa;
 
     public function __construct(
-        IdentityProvider $hostedIdentityProvider,
-        ProxyStateHandler $proxyStateHandler,
+        IdentityProvider        $hostedIdentityProvider,
+        ProxyStateHandler       $proxyStateHandler,
         AssertionSigningService $assertionSigningService,
-        AttributeDictionary $attributeDictionary,
-        Loa $intrinsicLoa,
-        DateTime $now = null
+        AttributeDictionary     $attributeDictionary,
+        AttributeDefinition     $internalCollabPersonIdAttribute,
+        Loa                     $intrinsicLoa,
+        DateTime                $now = null
     ) {
-        $this->hostedIdentityProvider    = $hostedIdentityProvider;
-        $this->proxyStateHandler         = $proxyStateHandler;
-        $this->assertionSigningService   = $assertionSigningService;
-        $this->attributeDictionary       = $attributeDictionary;
-        $this->intrinsicLoa              = $intrinsicLoa;
-        $this->currentTime = is_null($now) ? new DateTime('now', new DateTimeZone('UTC')): $now;
+        $this->hostedIdentityProvider = $hostedIdentityProvider;
+        $this->proxyStateHandler = $proxyStateHandler;
+        $this->assertionSigningService = $assertionSigningService;
+        $this->attributeDictionary = $attributeDictionary;
+        $this->internalCollabPersonIdAttribute = $internalCollabPersonIdAttribute;
+        $this->intrinsicLoa = $intrinsicLoa;
+        $this->currentTime = is_null($now) ? new DateTime('now', new DateTimeZone('UTC')) : $now;
     }
 
     /**
@@ -93,7 +101,6 @@ class ProxyResponseService
      */
     public function createProxyResponse(Assertion $assertion, $destination, $loa = null)
     {
-
         $newAssertion = new Assertion();
         $newAssertion->setNotBefore($this->currentTime->getTimestamp());
         $newAssertion->setNotOnOrAfter($this->getTimestamp('PT5M'));
@@ -103,22 +110,17 @@ class ProxyResponseService
 
         $this->assertionSigningService->signAssertion($newAssertion);
         $this->addSubjectConfirmationFor($newAssertion, $destination);
-
         $translatedAssertion = $this->attributeDictionary->translate($assertion);
         $eptiNameId = $translatedAssertion->getAttributeValue('eduPersonTargetedID');
         $internalCollabPersonId = $translatedAssertion->getAttributeValue('internalCollabPersonId');
-
-        // Perform some input validation on the eptiNameId that was received.
+        // Perform some input validation on the eptiNameId and/or internal-collabPersonId that was received.
         if (is_null($eptiNameId) && is_null($internalCollabPersonId)) {
-            throw new RuntimeException('Neither "urn:mace:dir:attribute-def:eduPersonTargetedID" or "urn:mace:surf.nl:attribute-def:internal-collabPersonId" is present');
-        } elseif (is_null($internalCollabPersonId) && (!array_key_exists(0, $eptiNameId) || !$eptiNameId[0]->value)) {
             throw new RuntimeException(
-                'The "urn:mace:dir:attribute-def:eduPersonTargetedID" attribute does not contain a NameID with a value.'
+                'Neither "urn:mace:dir:attribute-def:eduPersonTargetedID" nor ' .
+                '"urn:mace:surf.nl:attribute-def:internal-collabPersonId" is present'
             );
         }
-
-        $newAssertion->setNameId($eptiNameId[0]);
-
+        $this->updateNewAssertionWith($eptiNameId, $internalCollabPersonId, $newAssertion, $assertion);
         $newAssertion->setValidAudiences([$this->proxyStateHandler->getRequestServiceProvider()]);
 
         $this->addAuthenticationStatementTo($newAssertion, $assertion);
@@ -136,13 +138,13 @@ class ProxyResponseService
      */
     private function addSubjectConfirmationFor(Assertion $newAssertion, $destination)
     {
-        $confirmation         = new SubjectConfirmation();
+        $confirmation = new SubjectConfirmation();
         $confirmation->Method = Constants::CM_BEARER;
 
-        $confirmationData                      = new SubjectConfirmationData();
-        $confirmationData->InResponseTo        = $this->proxyStateHandler->getRequestId();
-        $confirmationData->Recipient           = $destination;
-        $confirmationData->NotOnOrAfter        = $newAssertion->getNotOnOrAfter();
+        $confirmationData = new SubjectConfirmationData();
+        $confirmationData->InResponseTo = $this->proxyStateHandler->getRequestId();
+        $confirmationData->Recipient = $destination;
+        $confirmationData->NotOnOrAfter = $newAssertion->getNotOnOrAfter();
 
         $confirmation->SubjectConfirmationData = $confirmationData;
 
@@ -156,7 +158,7 @@ class ProxyResponseService
     private function addAuthenticationStatementTo(Assertion $newAssertion, Assertion $assertion)
     {
         $newAssertion->setAuthnInstant($assertion->getAuthnInstant());
-        $newAssertion->setAuthnContextClassRef((string) $this->intrinsicLoa);
+        $newAssertion->setAuthnContextClassRef((string)$this->intrinsicLoa);
 
         $authority = $assertion->getAuthenticatingAuthority();
         $newAssertion->setAuthenticatingAuthority(
@@ -199,5 +201,29 @@ class ProxyResponseService
         }
 
         return $time->getTimestamp();
+    }
+
+    private function updateNewAssertionWith(
+        $eptiNameId,
+        $internalCollabPersonId,
+        Assertion $newAssertion,
+        Assertion $originalAssertion
+    ) :void {
+        if (!$internalCollabPersonId && $eptiNameId) {
+            if (is_null($internalCollabPersonId) && (!array_key_exists(0, $eptiNameId) || !$eptiNameId[0]->value)) {
+                throw new RuntimeException(
+                    'The "urn:mace:dir:attribute-def:eduPersonTargetedID" attribute does not contain a NameID ' .
+                    'with a value.'
+                );
+            }
+            $newAssertion->setNameId($eptiNameId[0]);
+        } else if ($internalCollabPersonId) {
+            // Remove the internal-collabPersonId from the assertion
+            $attributes = $newAssertion->getAttributes();
+            unset($attributes[$this->internalCollabPersonIdAttribute->getUrnMace()]);
+            $newAssertion->setAttributes($attributes);
+            // Use the supplied NameID as the NameID to the SP
+            $newAssertion->setNameId($originalAssertion->getNameId());
+        }
     }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/Gateway/RespondServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/Gateway/RespondServiceTest.php
@@ -101,6 +101,11 @@ final class RespondServiceTest extends GatewaySamlTestCase
                 'urn:mace:dir:attribute-def:eduPersonTargetedID',
                 'urn:oid:1.3.6.1.4.1.5923.1.1.1.10',
             ],
+            [
+                'internalCollabPersonId',
+                'urn:mace:surf.nl:attribute-def:internal-collabPersonId',
+                null,
+            ],
         ];
 
         $loaLevels = [


### PR DESCRIPTION
When EB sends the attribute urn:mace:surf.nl:attribute-def:internal-collabPersonId:
* Use this attribute's value as the person's identifier Stepup uses internally.
* Remove this attribute from the set of attributes. It must not be released to the SP in any situation,
* Use the supplied NameID as the NameID to the SP
* Treat the epTID not specially when present. If it's present it will be released to the SP just like another attribute that would be present.

Otherwise, when the attribute is not set:
* Keep current behaviour = Use NameID as person's identifier ,Use epTID as value for NameID for SP, 

Story: https://www.pivotaltracker.com/story/show/181115261