### PR TITLE
Resolve GSSP metadata generation twig environment configuration issue

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/ResponseRenderingService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/ResponseRenderingService.php
@@ -22,7 +22,7 @@ use SAML2\Constants;
 use SAML2\Response as SAMLResponse;
 use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseBuilder;
 use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
-use Symfony\Bundle\TwigBundle\TwigEngine;
+use Twig\Environment;
 use Symfony\Component\HttpFoundation\Response;
 
 final class ResponseRenderingService
@@ -33,21 +33,21 @@ final class ResponseRenderingService
     private $responseBuilder;
 
     /**
-     * @var TwigEngine
+     * @var Environment
      */
-    private $twigEngine;
+    private $templateEngine;
 
     /**
      * SamlResponseRenderingService constructor.
      * @param ResponseBuilder $responseBuilder
-     * @param TwigEngine $twigEngine
+     * @param Environment $templateEngine
      */
     public function __construct(
         ResponseBuilder $responseBuilder,
-        TwigEngine $twigEngine
+        Environment     $templateEngine
     ) {
         $this->responseBuilder = $responseBuilder;
-        $this->twigEngine = $twigEngine;
+        $this->templateEngine = $templateEngine;
     }
 
     /**
@@ -91,7 +91,7 @@ final class ResponseRenderingService
      */
     public function renderResponse(
         ResponseContext $context,
-        SAMLResponse $response
+        SAMLResponse    $response
     ) {
         return $this->renderSamlResponse($context, 'consume_assertion', $response);
     }
@@ -104,16 +104,18 @@ final class ResponseRenderingService
      */
     private function renderSamlResponse(
         ResponseContext $context,
-        $view,
-        SAMLResponse $response
+        string          $view,
+        SAMLResponse    $response
     ) {
-        return $this->twigEngine->renderResponse(
-            'SurfnetStepupGatewayGatewayBundle:gateway:' . $view . '.html.twig',
-            [
-                'acu'        => $context->getDestination(),
-                'response'   => $this->getResponseAsXML($response),
-                'relayState' => $context->getRelayState()
-            ]
+        return (new Response)->setContent(
+            $this->templateEngine->render(
+                'SurfnetStepupGatewayGatewayBundle:gateway:' . $view . '.html.twig',
+                [
+                    'acu' => $context->getDestination(),
+                    'response' => $this->getResponseAsXML($response),
+                    'relayState' => $context->getRelayState()
+                ]
+            )
         );
     }
 

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/DependencyInjection/SurfnetStepupGatewaySamlStepupProviderExtension.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/DependencyInjection/SurfnetStepupGatewaySamlStepupProviderExtension.php
@@ -231,7 +231,7 @@ class SurfnetStepupGatewaySamlStepupProviderExtension extends Extension
         $container->setDefinition('gssp.provider.' . $provider . 'metadata.configuration', $metadataConfiguration);
 
         $metadataFactory = new Definition('Surfnet\SamlBundle\Metadata\MetadataFactory', [
-            new Reference('templating'),
+            new Reference('twig'),
             new Reference('router'),
             new Reference('surfnet_saml.signing_service'),
             new Reference('gssp.provider.' . $provider . 'metadata.configuration')

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Resources/config/services.yml
@@ -33,14 +33,6 @@ services:
             publicKey: '%saml_metadata_publickey%'
             privateKey: '%saml_metadata_privatekey%'
 
-    second_factor_only.metadata_factory:
-        class: Surfnet\SamlBundle\Metadata\MetadataFactory
-        arguments:
-            - "@templating"
-            - "@router"
-            - "@surfnet_saml.signing_service"
-            - "@second_factor_only.configuration.metadata"
-
     second_factor_only.response_rendering:
         class: Surfnet\StepupGateway\GatewayBundle\Service\ResponseRenderingService
         arguments:


### PR DESCRIPTION
Work done in this pull request:

- The local service `second_factor_only.metadata_factory` has now been removed so it uses the `Stepup-saml-bundle` configuration from the Stepup Saml Bundle.
- Update `SurfnetStepupGatewaySamlStepupProviderExtension.php` to use the new rendering method `twig` instead of the no longer available `templating`
- Update `ResponseRenderingService.php`

https://www.pivotaltracker.com/story/show/181710432