### PR TITLE
Repair Behat tests

### DIFF
--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - ../certificates/idp.crt:/etc/nginx/certs/gateway.stepup.example.com.crt
             - ../certificates/idp.key:/etc/nginx/certs/gateway.stepup.example.com.key
         environment:
-            APP_ENV: webtest
+            APP_ENV: test
         ports:
             - 443:443
         depends_on:
@@ -41,7 +41,7 @@ services:
         volumes:
             - ../../:/var/www
         environment:
-            APP_ENV: webtest
+            APP_ENV: test
             PHP_IDE_CONFIG: "serverName=gateway.stepup.example.com"
             XDEBUG_CONFIG: "remote_enable=1 remote_connect_back=1 remote_port=9001 idekey=PHPSTORM"
         user: '${UID}:${GID}'

--- a/ci/docker/init.sh
+++ b/ci/docker/init.sh
@@ -12,5 +12,5 @@ docker-compose exec -T php-fpm.stepup.example.com bash -c '
   cp ./ci/certificates/* ./app/files/ && \
   composer install --prefer-dist -n -o --no-scripts && \
   composer frontend-install && \
-  ./bin/console assets:install --env=webtest --verbose
+  ./bin/console assets:install --env=test --verbose
 '

--- a/ci/docker/nginx/nginx.conf
+++ b/ci/docker/nginx/nginx.conf
@@ -29,8 +29,8 @@ server {
         # fastcgi_param APP_ENV prod;
         # fastcgi_param APP_SECRET <app-secret-id>;
         # fastcgi_param DATABASE_URL "mysql://db_user:db_pass@host:3306/db_name";
-        fastcgi_param SYMFONY_ENV webtest;
-        fastcgi_param APP_ENV webtest;
+        fastcgi_param SYMFONY_ENV test;
+        fastcgi_param APP_ENV test;
 
         # When you are using symlinks to link the document root to the
         # current version of your application, you should pass the real

--- a/ci/qa/behat.yml
+++ b/ci/qa/behat.yml
@@ -39,3 +39,8 @@ default:
           goutte:
             guzzle_parameters:
               verify: False
+    Behat\Symfony2Extension:
+      kernel:
+        class: 'App\Kernel'
+        env: smoketest
+        debug: true

--- a/config/legacy/parameters.yaml.dist
+++ b/config/legacy/parameters.yaml.dist
@@ -18,7 +18,7 @@ parameters:
 
     # Database connection
     database_driver:   pdo_mysql
-    database_host:     127.0.0.1
+    database_host:     db.stepup.example.com
     database_port:     ~
 
     # The database server version is used in the dbal configuration and is required to prevent issues when the database

--- a/config/packages/smoketest/doctrine.yaml
+++ b/config/packages/smoketest/doctrine.yaml
@@ -5,8 +5,8 @@ doctrine:
       gateway:
         driver:   "%database_driver%"
         port:     "%database_port%"
-        host:     localhost
-        dbname:   gateway_test
-        user:     root
-        password: password
+        host:     db.stepup.example.com
+        dbname:   gateway
+        user:     gateway
+        password: gateway
         charset:  UTF8

--- a/config/packages/smoketest/surfnet_saml.yaml
+++ b/config/packages/smoketest/surfnet_saml.yaml
@@ -3,20 +3,19 @@ surfnet_saml:
     service_provider:
       enabled: true
       assertion_consumer_route: gateway_serviceprovider_consume_assertion
-      public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
-      private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
+      public_key: /var/www/ci/certificates/sp.crt
+      private_key: /var/www/ci/certificates/sp.pem
     identity_provider:
       enabled: true
       service_provider_repository: gateway.entity_service
       sso_route: gateway_identityprovider_sso
-      public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
-      private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
+      public_key: /var/www/ci/certificates/idp.crt
+      private_key: /var/www/ci/certificates/idp.pem
       certificate: null
     metadata:
       entity_id_route: gateway_saml_metadata
-      public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
-      private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
-
+      public_key: /var/www/ci/certificates/sp.crt
+      private_key: /var/www/ci/certificates/sp.pem
   remote:
     identity_provider:
       certificate: MIIC6jCCAdICCQC9cRx5wiwWOjANBgkqhkiG9w0BAQsFADA3MRwwGgYDVQQDDBNTZWxmU2VydmljZSBTQU1MIFNQMRcwFQYDVQQKDA5EZXZlbG9wbWVudCBWTTAeFw0xODA3MzAxMjMwNDdaFw0yMzA3MjkxMjMwNDdaMDcxHDAaBgNVBAMME1NlbGZTZXJ2aWNlIFNBTUwgU1AxFzAVBgNVBAoMDkRldmVsb3BtZW50IFZNMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhbI0Xy682DuvWchg6FYnI+DNwLXef2XExM4YVRBaMMsOZ3rBtQUTMSqYan6SK/BOEXLs0rNiJjyM0dn+F98wg3fv5zIADlvfk3LBVdcGsrpVfFUWtSa73yMgbROy8/RJADbUJE/HUB3ZmdjdiuD2Cui2aoWwT2HR8ukJwmoxiu45IWFPbqPQ7/1mH644JPOWTPLTv4OGGLQo8MNrP1oRCiZ0IEL4CQeGOOju5rfIJ0bTVm0UmelT4hGaqZovBMwXp3QV41akJ7UEMEBK2YMnLQy47Xuzi7aTDhJlvHcJ8mfH2NbjRh7hJoACVRTvQloxajgkr1iGMiWiiqT0e+YYwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBwZ0gRHvR8B8KivrXrhWNL9uLvWhEAH7OiDqo+fywkBp5KEuDJcbbvEPftHunSAGylg7M2xKuBIGamFpp74WDJccrtZ1jJ4qqnacUDRQrTLqqMZKqGpFOU0xjKkSxSGRuMtGN9/7er/TeonjQ0XBvjYvTomy3b5aCLVWRvEfKu2g1sDd8uhr62RY/HfMgidEt7LHDolkCVg+6JzY3OTcgeHga3cvYObOYPplxw1YPq5+BqqxaUW4nfb5DtK33bZBYMeyV6BZtSggc5Z/19aPx/s0bf6ySTUyB3lRqe5d3etCns4bGidORCl/6EZiXwVcPvmYmxYXqmuNWfps7isUvo

--- a/config/services_test.yml
+++ b/config/services_test.yml
@@ -18,6 +18,21 @@ services:
   Surfnet\StepupGateway\Behat\MinkContext:
     class: Surfnet\StepupGateway\Behat\MinkContext
 
+  Surfnet\StepupGateway\Behat\Repository\SecondFactorRepository:
+    class: Surfnet\StepupGateway\Behat\Repository\SecondFactorRepository
+    arguments:
+      - '@Surfnet\StepupGateway\Behat\Repository\Connection'
+
+  Surfnet\StepupGateway\Behat\Repository\SamlEntityRepository:
+    class: Surfnet\StepupGateway\Behat\Repository\SamlEntityRepository
+    arguments:
+      - '@Surfnet\StepupGateway\Behat\Repository\Connection'
+
+  Surfnet\StepupGateway\Behat\Repository\WhitelistRepository:
+    class: Surfnet\StepupGateway\Behat\Repository\WhitelistRepository
+    arguments:
+      - '@Surfnet\StepupGateway\Behat\Repository\Connection'
+
   Surfnet\StepupGateway\Behat\Repository\Connection:
     class: Surfnet\StepupGateway\Behat\Repository\Connection
     arguments:
@@ -28,6 +43,11 @@ services:
 
   Surfnet\StepupGateway\Behat\Service\FixtureService:
     class: Surfnet\StepupGateway\Behat\Service\FixtureService
+    public: true
+    arguments:
+      - '@Surfnet\StepupGateway\Behat\Repository\SecondFactorRepository'
+      - '@Surfnet\StepupGateway\Behat\Repository\SamlEntityRepository'
+      - '@Surfnet\StepupGateway\Behat\Repository\WhitelistRepository'
 
   Surfnet\StepupGateway\Behat\Controller\ServiceProviderController:
     class: Surfnet\StepupGateway\Behat\Controller\ServiceProviderController

--- a/public/index.php
+++ b/public/index.php
@@ -20,6 +20,13 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
     Request::setTrustedHosts([$trustedHosts]);
 }
 
+// To run behat tests in smoketest mode, the app env needs to be 'dev' or 'test'
+// and the user agent needs to be that of the behat guzzle client.
+$isTestOrDev = ($_SERVER['APP_ENV'] === 'dev' || $_SERVER['APP_ENV'] === 'test');
+if ($isTestOrDev && $_SERVER['HTTP_USER_AGENT'] === 'Symfony BrowserKit') {
+    $_SERVER['APP_ENV'] = 'smoketest';
+}
+
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -21,7 +21,6 @@ namespace Surfnet\StepupGateway\Behat;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeFeatureScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Behat\Tester\Exception\PendingException;
 use Surfnet\StepupGateway\Behat\Service\FixtureService;
 
 class FeatureContext implements Context
@@ -55,8 +54,8 @@ class FeatureContext implements Context
     {
         // Generate test databases
         echo "Preparing test schemas\n";
-        shell_exec("/var/www/app/console doctrine:schema:drop --env=webtest --force");
-        shell_exec("/var/www/app/console doctrine:schema:create --env=webtest");
+        shell_exec("/var/www/bin/console doctrine:schema:drop --env=webtest --force");
+        shell_exec("/var/www/bin/console doctrine:schema:create --env=webtest");
     }
 
     /**

--- a/tests/features/metadata.feature
+++ b/tests/features/metadata.feature
@@ -1,4 +1,4 @@
-@SKIP
+
 Feature: As a SP or IdP
   In order to know what features are available on the Stepup Gateway proxy
   I must be able to read the Stepup Gateway proxy metadata


### PR DESCRIPTION
For now I focussed on getting the Metadata test to work as we want to create additional tests for that scenario.

What changed: 
1. Tests used to run on Travis,
2. Tests now run on the GHA docker container,
3. Behat setup needed Symfony integration,
4. Behat config needed some adjustment,
5. The test database needed to be setup.

What remains to be done:
1. The test database setup could be improved upon, now only one database is provisioned. An additional database could be created using the database init scripts feature of the mariadb container. This did not work due to permission issues.
2. The other behat tests are not yet 'un skipped'. They might need other maintainance that I have no time for at this point.
3. The most important issue: the front controller (index.php) has been made aware of a behat style browser. If a browser of that kind starts visiting the application. The environment is set to `smoketest`. This is a potential attack vector/security risk. We need to think of a solution and implement this in this PR.

:warning: Warning
The test-integration fails on a yarn-audit security warning. This needs to be addressed on another PR.