### PR TITLE
Add Behat tests to validate metadata endpoints

### DIFF
--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Resources/config/services.yml
@@ -33,11 +33,19 @@ services:
             publicKey: '%saml_metadata_publickey%'
             privateKey: '%saml_metadata_privatekey%'
 
+    second_factor_only.metadata_factory:
+        class: Surfnet\SamlBundle\Metadata\MetadataFactory
+        arguments:
+            - "@twig"
+            - "@router"
+            - "@surfnet_saml.signing_service"
+            - "@second_factor_only.configuration.metadata"
+
     second_factor_only.response_rendering:
         class: Surfnet\StepupGateway\GatewayBundle\Service\ResponseRenderingService
         arguments:
             - "@gateway.proxy.response_builder"
-            - "@templating"
+            - "@twig"
 
     second_factor_only.response_context:
         class: Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext

--- a/tests/features/metadata.feature
+++ b/tests/features/metadata.feature
@@ -8,13 +8,13 @@ Feature: As a SP or IdP
     And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
     And the response should match xpath '//md:SingleSignOnService[@Location="https://gateway.stepup.example.com/authentication/single-sign-on"]'
 
-  Scenario: View the SecondFactor metadata of the Gateway
+  Scenario: View the SecondFactor of the Gateway
     Given I am on "/second-factor-only/metadata"
     Then the response should match xpath '//md:EntityDescriptor[@entityID="https://gateway.stepup.example.com/second-factor-only/metadata"]'
     And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
     And the response should match xpath '//md:SingleSignOnService[@Location="https://gateway.stepup.example.com/second-factor-only/single-sign-on"]'
 
-  Scenario: View the GSSP Azuremfa metadata of the Gateway
+  Scenario: View the GSSP Azure MFA metadata of the Gateway
     Given I am on "/gssp/azuremfa/metadata"
     Then the response should match xpath '//md:EntityDescriptor[@entityID="https://gateway.stepup.example.com/gssp/azuremfa/metadata"]'
     And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
@@ -26,7 +26,7 @@ Feature: As a SP or IdP
     And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
     And the response should match xpath '//md:SingleSignOnService[@Location="https://gateway.stepup.example.com/gssp/tiqr/single-sign-on"]'
 
-  Scenario: View the GSSP webauthn metadata of the Gateway
+  Scenario: View the GSSP WebAuthn metadata of the Gateway
     Given I am on "/gssp/webauthn/metadata"
     Then the response should match xpath '//md:EntityDescriptor[@entityID="https://gateway.stepup.example.com/gssp/webauthn/metadata"]'
     And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'

--- a/tests/features/metadata.feature
+++ b/tests/features/metadata.feature
@@ -1,4 +1,3 @@
-
 Feature: As a SP or IdP
   In order to know what features are available on the Stepup Gateway proxy
   I must be able to read the Stepup Gateway proxy metadata
@@ -8,3 +7,27 @@ Feature: As a SP or IdP
     Then the response should match xpath '//md:EntityDescriptor[@entityID="https://gateway.stepup.example.com/authentication/metadata"]'
     And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
     And the response should match xpath '//md:SingleSignOnService[@Location="https://gateway.stepup.example.com/authentication/single-sign-on"]'
+
+  Scenario: View the SecondFactor metadata of the Gateway
+    Given I am on "/second-factor-only/metadata"
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://gateway.stepup.example.com/second-factor-only/metadata"]'
+    And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
+    And the response should match xpath '//md:SingleSignOnService[@Location="https://gateway.stepup.example.com/second-factor-only/single-sign-on"]'
+
+  Scenario: View the GSSP Azuremfa metadata of the Gateway
+    Given I am on "/gssp/azuremfa/metadata"
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://gateway.stepup.example.com/gssp/azuremfa/metadata"]'
+    And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
+    And the response should match xpath '//md:SingleSignOnService[@Location="https://gateway.stepup.example.com/gssp/azuremfa/single-sign-on"]'
+
+  Scenario: View the GSSP Tiqr metadata of the Gateway
+    Given I am on "/gssp/tiqr/metadata"
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://gateway.stepup.example.com/gssp/tiqr/metadata"]'
+    And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
+    And the response should match xpath '//md:SingleSignOnService[@Location="https://gateway.stepup.example.com/gssp/tiqr/single-sign-on"]'
+
+  Scenario: View the GSSP webauthn metadata of the Gateway
+    Given I am on "/gssp/webauthn/metadata"
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://gateway.stepup.example.com/gssp/webauthn/metadata"]'
+    And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"]'
+    And the response should match xpath '//md:SingleSignOnService[@Location="https://gateway.stepup.example.com/gssp/webauthn/single-sign-on"]'


### PR DESCRIPTION
The following work has been done:
- Add  Behat tests to validate metadata endpoints
- Re-add second_factor_only.metadata_factory service

Task 1 of [181710432](https://www.pivotaltracker.com/story/show/181710432)

The build currently fails due to a security vulnerability 