### PR TITLE
Store resulting loa, not the required

### DIFF
--- a/ci/docker/php-fpm/Dockerfile
+++ b/ci/docker/php-fpm/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-install pdo_mysql exif gd gmp sodium
 
 # Xdebug
-RUN pecl install xdebug && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini;
+RUN pecl install xdebug-3.1.6 && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini;
 
 # Composer
 RUN curl -sL https://getcomposer.org/installer | php -- --install-dir /usr/bin --filename composer

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,6 @@
             "@phpmd",
             "@test",
             "@behat",
-            "@download-security-checker",
             "@security-tests",
             "@yarn-audit"
         ],
@@ -117,8 +116,7 @@
             "yarn install --frozen-lockfile",
             "yarn encore production"
         ],
-        "download-security-checker": "if [ ! -f local-php-security-checker ]; then curl -s https://api.github.com/repos/fabpot/local-php-security-checker/releases/latest | grep -E \"browser_download_url(.+)linux_386\" | cut -d : -f 2,3 | tr -d \\\" | xargs -I{} curl -L --output local-php-security-checker {} && chmod +x local-php-security-checker; fi",
-        "security-tests": "./local-php-security-checker"
+        "security-tests": "composer audit"
     },
     "config": {
         "allow-plugins": {

--- a/src/Surfnet/StepupGateway/ApiBundle/Tests/TestDouble/Service/SmsService.php
+++ b/src/Surfnet/StepupGateway/ApiBundle/Tests/TestDouble/Service/SmsService.php
@@ -26,7 +26,7 @@ use function setcookie;
  */
 class SmsService implements SmsServiceInterface
 {
-    const CHALLENGE_COOKIE_PREFIX = 'smoketest-sms-service-';
+    const CHALLENGE_COOKIE_PREFIX = 'smoketest-sms-service';
 
     /**
      * @inheritDoc
@@ -35,7 +35,7 @@ class SmsService implements SmsServiceInterface
     {
         // Store the SMS code in a session identified by the identity of the user requesting the step up allowing
         // later access to the challenge code
-        setcookie(sprintf(self::CHALLENGE_COOKIE_PREFIX . $command->recipient), $command->body);
+        setcookie(sprintf(self::CHALLENGE_COOKIE_PREFIX), $command->body);
         // beep boop, sending SMS ...
         return true;
     }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/SecondFactor.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/SecondFactor.php
@@ -114,22 +114,13 @@ class SecondFactor
     {
     }
 
-    /**
-     * @param Loa $loa
-     * @param SecondFactorTypeService $service
-     * @return bool
-     */
-    public function canSatisfy(Loa $loa, SecondFactorTypeService $service)
+    public function canSatisfy(Loa $loa, SecondFactorTypeService $service): bool
     {
         $secondFactorType = new SecondFactorType($this->secondFactorType);
         return $service->canSatisfy($secondFactorType, $loa, new VettingType($this->vettingType));
     }
 
-    /**
-     * @param SecondFactorTypeService $service
-     * @return int
-     */
-    public function getLoaLevel(SecondFactorTypeService $service)
+    public function getLoaLevel(SecondFactorTypeService $service): float
     {
         $secondFactorType = new SecondFactorType($this->secondFactorType);
         return $service->getLevel($secondFactorType, new VettingType($this->vettingType));

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
@@ -151,8 +151,6 @@ services:
         arguments:
             - "@gateway.service.sso_2fa_cookie_helper"
             - "@gateway.service.institution_configuration"
-            - "@surfnet_stepup.service.loa_resolution"
-            - "@second_factor_only.loa_resolution"
             - "@logger"
             - "@gateway.service.second_factor_service"
             - "@surfnet_stepup.service.second_factor_type"

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/CookieServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/CookieServiceTest.php
@@ -91,8 +91,6 @@ class CookieServiceTest extends TestCase
         // Not all dependencies are included for real, the ones not focussed on crypto and cookie storage are mocked
         $logger = Mockery::mock(LoggerInterface::class)->shouldIgnoreMissing();
         $this->institutionService = Mockery::mock(InstitutionConfigurationService::class);
-        $this->gwLoaResolution = Mockery::mock(LoaResolutionService::class);
-        $this->sfoLoaResolution = Mockery::mock(SfoLoaResolutionService::class);
         $this->secondFactorService = Mockery::mock(SecondFactorService::class);
         $this->secondFactorTypeService = Mockery::mock(SecondFactorTypeService::class);
         $this->configuration = $configuration;
@@ -101,8 +99,6 @@ class CookieServiceTest extends TestCase
         $this->service = new CookieService(
             $cookieHelper,
             $this->institutionService,
-            $this->gwLoaResolution,
-            $this->sfoLoaResolution,
             $logger,
             $this->secondFactorService,
             $this->secondFactorTypeService
@@ -143,6 +139,8 @@ class CookieServiceTest extends TestCase
         $sfMock = Mockery::mock(SecondFactor::class)->makePartial();
         $sfMock->secondFactorId = 'sf-id-1234';
         $sfMock->institution = 'institution-a';
+        $sfMock->secondFactorType = 'sms';
+        $sfMock->vettingType = 'on-premise';
 
         $this->responseContext
             ->shouldReceive('getSelectedSecondFactor')
@@ -160,13 +158,12 @@ class CookieServiceTest extends TestCase
         $this->responseContext
             ->shouldReceive('getRequiredLoa')
             ->andReturn('example.org:loa-2.0');
-        $this->gwLoaResolution
-            ->shouldReceive('getLoa')
-            ->with('example.org:loa-2.0')
-            ->andReturn(new Loa(2.0, 'example.org:loa-2.0'));
         $this->responseContext
             ->shouldReceive('getIdentityNameId')
             ->andReturn('james-hoffman');
+        $this->secondFactorTypeService
+            ->shouldReceive('getLevel')
+            ->andReturn(2.0);
 
         $response = $this->service->handleSsoOn2faCookieStorage($this->responseContext, $request, $response);
 
@@ -194,6 +191,8 @@ class CookieServiceTest extends TestCase
         $sfMock = Mockery::mock(SecondFactor::class)->makePartial();
         $sfMock->secondFactorId = 'sf-id-1234';
         $sfMock->institution = 'institution-a';
+        $sfMock->secondFactorType = 'yubikey';
+        $sfMock->vettingType = 'on-premise';
 
         $this->responseContext
             ->shouldReceive('getSelectedSecondFactor')
@@ -211,13 +210,12 @@ class CookieServiceTest extends TestCase
         $this->responseContext
             ->shouldReceive('getRequiredLoa')
             ->andReturn('example.org:loa-2.0');
-        $this->gwLoaResolution
-            ->shouldReceive('getLoa')
-            ->with('example.org:loa-2.0')
-            ->andReturn(new Loa(2.0, 'example.org:loa-2.0'));
         $this->responseContext
             ->shouldReceive('getIdentityNameId')
             ->andReturn('james-hoffman');
+        $this->secondFactorTypeService
+            ->shouldReceive('getLevel')
+            ->andReturn(3.0);
 
         $response = $this->service->handleSsoOn2faCookieStorage($this->responseContext, $request, $response);
 

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -121,9 +121,6 @@ class FeatureContext implements Context
      */
     public function iShouldSeeTheSMSScreen()
     {
-        $this->minkContext->assertPageContainsText('Log in with SMS');
-        $this->minkContext->assertPageContainsText('Enter the received code on the next page');
-        $this->minkContext->pressButton('gateway_send_sms_challenge_send_challenge');
         $this->minkContext->assertPageContainsText('Enter the received SMS-code');
         $this->minkContext->assertPageContainsText('Send again');
     }
@@ -152,7 +149,10 @@ class FeatureContext implements Context
      */
     public function iEnterTheSmsVerificationCode()
     {
-        $this->minkContext->fillField('gateway_verify_sms_challenge_challenge', '432543');
+        $cookieValue = $this->minkContext->getSession()->getDriver()->getCookie('smoketest-sms-service');
+        $matches = [];
+        preg_match('/^Your\ SMS\ code:\ (.*)$/', $cookieValue, $matches);
+        $this->minkContext->fillField('gateway_verify_sms_challenge_challenge', $matches[1]);
         $this->minkContext->pressButton('gateway_verify_sms_challenge_verify_challenge');
         $this->minkContext->pressButton('Submit');
     }

--- a/tests/features/sso-on-2fa.feature
+++ b/tests/features/sso-on-2fa.feature
@@ -38,6 +38,27 @@ Feature: As an institution that uses the SSO on Second Factor authentication
     And the response should have a SSO-2FA cookie
     And the SSO-2FA cookie should contain "urn:collab:person:stepup.example.com:user-2"
 
+  Scenario: A successive higher LoA authentication asks the Yubikey second factor authentication
+    Given a user from "stepup.example.com" identified by "urn:collab:person:stepup.example.com:user-5" with a vetted "Yubikey" token
+    And a user from "stepup.example.com" identified by "urn:collab:person:stepup.example.com:user-5" with a vetted "SMS" token
+    When urn:collab:person:stepup.example.com:user-5 starts an authentication requiring LoA 2
+    Then I authenticate at the IdP as user-5
+    And I select my SMS token on the WAYG
+    Then I should see the SMS verification screen
+    And I enter the SMS verification code
+    Then the response should contain "You are logged in to SP"
+    And the response should contain "default-sp"
+    And the response should have a SSO-2FA cookie
+    And the SSO-2FA cookie should contain "urn:collab:person:stepup.example.com:user-5"
+    When urn:collab:person:stepup.example.com:user-5 starts an authentication requiring LoA 3
+    And I pass through the IdP
+    And I should see the Yubikey OTP screen
+    When I enter the OTP
+    Then the response should contain "You are logged in to SP"
+    And the response should contain "default-sp"
+    And the response should have a SSO-2FA cookie
+    And the SSO-2FA cookie should contain "urn:collab:person:stepup.example.com:user-5"
+
   Scenario: Cookie is only valid for the identity it was issued to
     Given a user from "stepup.example.com" identified by "urn:collab:person:stepup.example.com:user-3" with a vetted "Yubikey" token
     Given a user from "stepup.example.com" identified by "urn:collab:person:stepup.example.com:user-4" with a vetted "Yubikey" token


### PR DESCRIPTION
The required (required by SP) LoA was stored in the SSO cookie. That is not rigth, we want to store the LoA of the SF used to authenticate the rquired LoA. That LoA might be higher. An might assist the end user in not having to give another 2FA when another SP requires a higher LoA.

See: https://www.pivotaltracker.com/story/show/184060757
See: https://www.pivotaltracker.com/story/show/183402542