### PR TITLE
Set correct Issuer on SAML Failed Response

### DIFF
--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Service/Gateway/ConsumeAssertionService.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Service/Gateway/ConsumeAssertionService.php
@@ -107,8 +107,8 @@ class ConsumeAssertionService
         } catch (Exception $exception) {
             $message = sprintf('Could not process received Response, error: "%s"', $exception->getMessage());
             $logger->error($message);
-
-            throw new ResponseFailureException($message);
+            // Only pass along the original message back to the SP
+            throw new ResponseFailureException($exception->getMessage());
         }
 
         $adaptedAssertion = new AssertionAdapter($assertion);


### PR DESCRIPTION
When the GSSP authentication/registraion failed, the incorrect issuer was returned to the SP. That was rectified in this commit. The issuer is loaded from the correct context (cancelled SFO auth would return a SSO issuer where the SFO issuer should be used instead).

In addition the message that is posted back is also simplified. Only the Message provided by the remote IdP is used in this case.

This bugfix is hard to cover in test, as the error occured when a GSSP authentication was cancelled. It is not yet possible to test GSSP interactions in the Behat test suite.

See: https://www.pivotaltracker.com/story/show/179591654