### PR TITLE
Verify the SSO cookie expiration date

### DIFF
--- a/docs/SsoOn2Fa.md
+++ b/docs/SsoOn2Fa.md
@@ -19,6 +19,12 @@ The timestamp is used to verify if the cookie value did not expire. This is dete
 to the authentication timestamp found in the cookie. If those two exceed the current timestamp, the cookie is considered to be expired. Even tho the browser cookie itself 
 might still be alive. 
 
+The cookie lifetime can be configured with a grace period. This is useful when your setup include multiple StepUp gateways that are able to verify the cookie validity. 
+In that case a (minor) time difference between the nodes can cause a false positive invalid cookie scenario. By adding the grace period, the end user is not directly
+affected in a negative manner.
+
+At this point this grace period is configured to be 60 seconds in the `gateway.service.sso_2fa_expiration_helper` service definition in `src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml`
+
 The cookie value contains sensitive data, and its contents are authenticated and encrypted for that reason. We use the Paragonie Halite library for this. Halite uses XSalsa20 for encryption and BLAKE2b for message Authentication (MAC).
 
 If your encryption requirements differ from ours, you can simply provide a different encryption method by implementing a different `Surfnet\StepupGateway\GatewayBundle\Sso2fa\Crypto\CryptoHelperInterface`

--- a/docs/SsoOn2Fa.md
+++ b/docs/SsoOn2Fa.md
@@ -14,7 +14,10 @@ The cookie contains several values, used to ascertain if SSO can be given. These
 | `LoA`                            | The LoA of the second factor               |
 | `Timestamp`                      | The timestamp taken during authentication. |
 
-The cookie is used to verify the SSO is issued to the correct identity (user). And to check if the LoA requirement is satisfied by the SSO cookie. The timestamp is kept mainly for audit reasons.
+The cookie is used to verify the SSO is issued to the correct identity (user). And to check if the LoA requirement is satisfied by the SSO cookie. 
+The timestamp is used to verify if the cookie value did not expire. This is determined by adding the cookie expiration time (configured in `sso_cookie_lifetime` param) 
+to the authentication timestamp found in the cookie. If those two exceed the current timestamp, the cookie is considered to be expired. Even tho the browser cookie itself 
+might still be alive. 
 
 The cookie value contains sensitive data, and its contents are authenticated and encrypted for that reason. We use the Paragonie Halite library for this. Halite uses XSalsa20 for encryption and BLAKE2b for message Authentication (MAC).
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
@@ -138,6 +138,11 @@ services:
             - "@gateway.service.sso_2fa_cookie_config"
         public: false
 
+    gateway.service.sso_2fa_expiration_helper:
+        class: Surfnet\StepupGateway\GatewayBundle\Sso2fa\DateTime\ExpirationHelper
+        arguments:
+            $cookieLifetime: "%sso_cookie_lifetime%"
+
     gateway.service.sso_2fa_cookie_helper:
         class: Surfnet\StepupGateway\GatewayBundle\Sso2fa\Http\CookieHelper
         arguments:
@@ -151,10 +156,10 @@ services:
         arguments:
             - "@gateway.service.sso_2fa_cookie_helper"
             - "@gateway.service.institution_configuration"
-            - "@logger"
             - "@gateway.service.second_factor_service"
             - "@surfnet_stepup.service.second_factor_type"
-            - "@gssp.allowed_sps"
+            - "@gateway.service.sso_2fa_expiration_helper"
+            - "@logger"
 
     gateway.service.institution_configuration:
         class: Surfnet\StepupGateway\GatewayBundle\Service\InstitutionConfigurationService

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
@@ -142,6 +142,7 @@ services:
         class: Surfnet\StepupGateway\GatewayBundle\Sso2fa\DateTime\ExpirationHelper
         arguments:
             $cookieLifetime: "%sso_cookie_lifetime%"
+            $gracePeriod: 60
 
     gateway.service.sso_2fa_cookie_helper:
         class: Surfnet\StepupGateway\GatewayBundle\Sso2fa\Http\CookieHelper

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
@@ -27,7 +27,9 @@ use Surfnet\StepupGateway\GatewayBundle\Exception\RuntimeException;
 use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
 use Surfnet\StepupGateway\GatewayBundle\Service\InstitutionConfigurationService;
 use Surfnet\StepupGateway\GatewayBundle\Service\SecondFactorService;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\DateTime\ExpirationHelperInterface;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Exception\CookieNotFoundException;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Exception\InvalidAuthenticationTimeException;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Http\CookieHelperInterface;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValue;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValueInterface;
@@ -61,18 +63,24 @@ class CookieService implements CookieServiceInterface
      * @var SecondFactorTypeService
      */
     private $secondFactorTypeService;
+    /**
+     * @var ExpirationHelperInterface
+     */
+    private $expirationHelper;
 
     public function __construct(
         CookieHelperInterface $cookieHelper,
         InstitutionConfigurationService $institutionConfigurationService,
-        LoggerInterface $logger,
         SecondFactorService $secondFactorService,
-        SecondFactorTypeService $secondFactorTypeService
+        SecondFactorTypeService $secondFactorTypeService,
+        ExpirationHelperInterface $expirationHelper,
+        LoggerInterface $logger
     ) {
         $this->cookieHelper = $cookieHelper;
         $this->institutionConfigurationService = $institutionConfigurationService;
         $this->secondFactorService = $secondFactorService;
         $this->secondFactorTypeService = $secondFactorTypeService;
+        $this->expirationHelper = $expirationHelper;
         $this->logger = $logger;
     }
 
@@ -101,7 +109,7 @@ class CookieService implements CookieServiceInterface
             if (!$secondFactor) {
                 throw new RuntimeException(sprintf('Second Factor token not found with ID: %s', $secondFactorId));
             }
-            // Test if the institution of the Idenity this SF belongs to has SSO on 2FA enabled
+            // Test if the institution of the Identity this SF belongs to has SSO on 2FA enabled
             $isEnabled = $this->institutionConfigurationService->ssoOn2faEnabled($secondFactor->institution);
             $this->logger->notice(
                 sprintf(
@@ -178,6 +186,19 @@ class CookieService implements CookieServiceInterface
             );
             return false;
         }
+        try {
+            $isExpired = $this->expirationHelper->isExpired($ssoCookie);
+            if ($isExpired) {
+                $this->logger->notice(
+                    'The SSO on 2FA cookie has expired. Meaning [authentication time] + [cookie lifetime] is in the past'
+                );
+                return false;
+            }
+        } catch (InvalidAuthenticationTimeException $e) {
+            $this->logger->notice('The SSO on 2FA cookie contained an invalid authentication time', [$e->getMessage()]);
+            return false;
+        }
+
         /** @var SecondFactor $secondFactor */
         foreach ($secondFactorCollection as $secondFactor) {
             $loa = $secondFactor->getLoaLevel($this->secondFactorTypeService);

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/DateTime/ExpirationHelper.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/DateTime/ExpirationHelper.php
@@ -32,15 +32,23 @@ class ExpirationHelper implements ExpirationHelperInterface
     private $now;
 
     /*
+     * The period in seconds that we still acknowledge the
+     * cookie even tho the expiration was reached. This accounts
+     * for server time/sync differences that may occur.
+     */
+    private $gracePeriod;
+
+    /*
      * The SSO on 2FA cookie lifetime in seconds
      *
      * See: config/legacy/parameters.yaml sso_cookie_lifetime
      */
     private $cookieLifetime;
 
-    public function __construct(int $cookieLifetime, CoreDateTime $now = null)
+    public function __construct(int $cookieLifetime, int $gracePeriod, CoreDateTime $now = null)
     {
         $this->cookieLifetime = $cookieLifetime;
+        $this->gracePeriod = $gracePeriod;
         if (!$now) {
             $now = DateTime::now();
         }
@@ -70,7 +78,7 @@ class ExpirationHelper implements ExpirationHelperInterface
             );
         }
 
-        $expirationTimestamp = $authenticationTimestamp + $this->cookieLifetime;
+        $expirationTimestamp = $authenticationTimestamp + $this->cookieLifetime + $this->gracePeriod;
         $currentTimestamp = $this->now->getTimestamp();
         // Is the current time greater than the expiration time?
         return $currentTimestamp > $expirationTimestamp;

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/DateTime/ExpirationHelper.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/DateTime/ExpirationHelper.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Sso2fa\DateTime;
+
+use DateTime as CoreDateTime;
+use Surfnet\StepupBundle\DateTime\DateTime;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Exception\InvalidAuthenticationTimeException;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValueInterface;
+use TypeError;
+
+class ExpirationHelper implements ExpirationHelperInterface
+{
+    /**
+     * @var CoreDateTime
+     */
+    private $now;
+
+    /*
+     * The SSO on 2FA cookie lifetime in seconds
+     *
+     * See: config/legacy/parameters.yaml sso_cookie_lifetime
+     */
+    private $cookieLifetime;
+
+    public function __construct(int $cookieLifetime, CoreDateTime $now = null)
+    {
+        $this->cookieLifetime = $cookieLifetime;
+        if (!$now) {
+            $now = DateTime::now();
+        }
+        $this->now = $now;
+    }
+
+    public function isExpired(CookieValueInterface $cookieValue): bool
+    {
+        try {
+            $authenticationTimestamp = $cookieValue->authenticationTime();
+        } catch (TypeError $error) {
+            throw new InvalidAuthenticationTimeException(
+                'The authentication time contained a non-int value',
+                0,
+                $error
+            );
+        }
+        if ($authenticationTimestamp < 0) {
+            throw new InvalidAuthenticationTimeException(
+                'The authentication time is from before the Unix timestamp epoch'
+            );
+        }
+        if ($authenticationTimestamp > $this->now->getTimestamp()) {
+            throw new InvalidAuthenticationTimeException(
+                'The authentication time is from the future, which indicates the clock settings ' .
+                'are incorrect, or the time in the cookie value was tampered with.'
+            );
+        }
+
+        $expirationTimestamp = $authenticationTimestamp + $this->cookieLifetime;
+        $currentTimestamp = $this->now->getTimestamp();
+        // Is the current time greater than the expiration time?
+        return $currentTimestamp > $expirationTimestamp;
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/DateTime/ExpirationHelperInterface.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/DateTime/ExpirationHelperInterface.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Sso2fa\DateTime;
+
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValueInterface;
+
+/**
+ * Used to verify if the authentication time from the CookieValue
+ * surpasses the current timestamp. Which is determined by adding
+ * the cookie lifetime to the authentication time. And checking that
+ * against the current timestamp.
+ *
+ * The current timestamp can be set on this helper class in order
+ * to make testing more predictable. However, if this is not set
+ * explicitly it will use 'now' as the current timestamp.
+ */
+interface ExpirationHelperInterface
+{
+    public function isExpired(CookieValueInterface $cookieValue): bool;
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Exception/InvalidAuthenticationTimeException.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Exception/InvalidAuthenticationTimeException.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 /**
- * Copyright 2022 SURFnet bv
+ * Copyright 2023 SURFnet bv
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,11 @@
  * limitations under the License.
  */
 
-namespace Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject;
+namespace Surfnet\StepupGateway\GatewayBundle\Sso2fa\Exception;
 
-interface CookieValueInterface
+use Surfnet\StepupGateway\GatewayBundle\Exception\InvalidArgumentException;
+
+class InvalidAuthenticationTimeException extends InvalidArgumentException
 {
-    public static function deserialize(string $serializedData): CookieValueInterface;
 
-    public function serialize(): string;
-
-    public function meetsRequiredLoa(float $requiredLoa): bool;
-
-    public function authenticationTime(): int;
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/CookieValue.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/CookieValue.php
@@ -18,8 +18,9 @@
 
 namespace Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject;
 
-use Surfnet\StepupBundle\DateTime\DateTime;
+use DateTime;
 use function strtolower;
+use function strtotime;
 
 class CookieValue implements CookieValueInterface
 {
@@ -41,7 +42,8 @@ class CookieValue implements CookieValueInterface
         $cookieValue->tokenId = $secondFactorId;
         $cookieValue->identityId = $identityId;
         $cookieValue->loa = $loa;
-        $cookieValue->authenticationTime = DateTime::now()->format(DATE_ATOM);
+        $dateTime = new DateTime();
+        $cookieValue->authenticationTime = $dateTime->format(DATE_ATOM);
         return $cookieValue;
     }
 
@@ -85,5 +87,10 @@ class CookieValue implements CookieValueInterface
     public function issuedTo(string $identityNameId): bool
     {
         return strtolower($identityNameId) === strtolower($this->identityId);
+    }
+
+    public function authenticationTime(): int
+    {
+        return strtotime($this->authenticationTime);
     }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/NullCookieValue.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/NullCookieValue.php
@@ -34,4 +34,9 @@ class NullCookieValue implements CookieValueInterface
     {
         return false;
     }
+
+    public function authenticationTime(): int
+    {
+        return -1;
+    }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/DateTime/ExpirationHelperTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/DateTime/ExpirationHelperTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Test\Sso2fa\DateTime;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\DateTime\ExpirationHelper;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Exception\InvalidAuthenticationTimeException;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValue;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValueInterface;
+
+class ExpirationHelperTest extends TestCase
+{
+    /**
+     * @dataProvider expirationExpectations
+     */
+    public function test_is_expired(bool $isExpired, ExpirationHelper $helper, CookieValue $cookieValue)
+    {
+        self::assertEquals($isExpired, $helper->isExpired($cookieValue));
+    }
+
+    /**
+     * @dataProvider invalidTimeExpectations
+     */
+    public function test_strange_authentication_time_values(ExpirationHelper $helper, CookieValue $cookieValue)
+    {
+        self::expectException(InvalidAuthenticationTimeException::class);
+        $helper->isExpired($cookieValue);
+    }
+
+    public function expirationExpectations()
+    {
+        return [
+            'not expired' => [false, $this->makeExpirationHelper(3600, time()), $this->makeCookieValue(time())],
+            'not expired but about to be' => [false, $this->makeExpirationHelper(3600, time() + 3600), $this->makeCookieValue(time())],
+            'expired' => [true, $this->makeExpirationHelper(3600, time() + 3601), $this->makeCookieValue(time())],
+            'expired more' => [true, $this->makeExpirationHelper(3600, time() + 36000), $this->makeCookieValue(time())],
+        ];
+    }
+
+    public function invalidTimeExpectations()
+    {
+        $goodOldHelper = $this->makeExpirationHelper(3600, time());
+        return [
+            'before epoch' => [$goodOldHelper, $this->makeCookieValue(-1)],
+            'from the future' => [$goodOldHelper, $this->makeCookieValue(time() + 42)],
+            'invalid time input 1' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime('aint-no-time')],
+            'invalid time input 2' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime('9999-01-01')],
+            'invalid time input 3' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime('0001-01-01')],
+            'invalid time input 4' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime(-1.0)],
+            'invalid time input 5' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime(2.999)],
+            'invalid time input 6' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime(42)],
+            'invalid time input 7' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime(true)],
+            'invalid time input 8' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime(false)],
+            'invalid time input 9' => [$goodOldHelper, $this->makeCookieValueUnrestrictedAuthTime(null)],
+        ];
+    }
+
+    private function makeExpirationHelper(int $expirationTime, int $now) : ExpirationHelper
+    {
+        $time = new \DateTime();
+        $time->setTimestamp($now);
+        return new ExpirationHelper($expirationTime, $time);
+    }
+
+    private function makeCookieValue(int $authenticationTime) : CookieValueInterface
+    {
+        $dateTime = new \DateTime();
+        $dateTime->setTimestamp($authenticationTime);
+        $data = [
+            'tokenId' => 'tokenId',
+            'identityId' => 'identityId',
+            'loa' => 2.0,
+            'authenticationTime' => $dateTime->format(DATE_ATOM),
+        ];
+        return CookieValue::deserialize(json_encode($data));
+    }
+
+    private function makeCookieValueUnrestrictedAuthTime($authenticationTime) : CookieValueInterface
+    {
+        $data = [
+            'tokenId' => 'tokenId',
+            'identityId' => 'identityId',
+            'loa' => 2.0,
+            'authenticationTime' => $authenticationTime,
+        ];
+        return CookieValue::deserialize(json_encode($data));
+    }
+}


### PR DESCRIPTION
The cookie lifetime can be extended by the user. But the explicit lifetime of the cookie was not yet validated by the cookie service. Meaning you could extend the SSO lifetime by keeping your cookie alive.

As of this change, the authentication lifetime is checked against the current timestamp togegher with the cookie expiration time.

See: https://www.pivotaltracker.com/story/show/183402734
> the SSO cookie's timestamp is within the configured SSO lifetime