### PR TITLE
Ensure the SF is not revoked before SSO is given

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
@@ -199,6 +199,16 @@ class CookieService implements CookieServiceInterface
             return false;
         }
 
+        if (!$this->secondFactorService->findByUuid($ssoCookie->secondFactorId())) {
+            $this->logger->notice(
+                'The second factor stored in the SSO cookie was revoked or has otherwise became unknown to Gateway',
+                [
+                    'secondFactorIdFromCookie' => $ssoCookie->secondFactorId()
+                ]
+            );
+            return false;
+        }
+
         /** @var SecondFactor $secondFactor */
         foreach ($secondFactorCollection as $secondFactor) {
             $loa = $secondFactor->getLoaLevel($this->secondFactorTypeService);

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/CookieValue.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/CookieValue.php
@@ -84,6 +84,11 @@ class CookieValue implements CookieValueInterface
         return $this->identityId;
     }
 
+    public function secondFactorId(): string
+    {
+        return $this->tokenId;
+    }
+
     public function issuedTo(string $identityNameId): bool
     {
         return strtolower($identityNameId) === strtolower($this->identityId);

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/CookieValueInterface.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/CookieValueInterface.php
@@ -27,4 +27,6 @@ interface CookieValueInterface
     public function meetsRequiredLoa(float $requiredLoa): bool;
 
     public function authenticationTime(): int;
+
+    public function secondFactorId(): string;
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/NullCookieValue.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/NullCookieValue.php
@@ -39,4 +39,9 @@ class NullCookieValue implements CookieValueInterface
     {
         return -1;
     }
+
+    public function secondFactorId(): string
+    {
+        return '';
+    }
 }


### PR DESCRIPTION
Before we give SSO, a checklist is checked. On which one check missed. That is, that the token we gave the SSO on, is not revoked intermediately.

See: https://www.pivotaltracker.com/story/show/183402734
> the token in the cookie is still valid (i.e. activated, vetted)