### PR TITLE
Address some remaining SSO on 2FA issues

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -1,29 +1,24 @@
-
 monolog:
   channels: [authentication]
   handlers:
     prod-signaler:
       type: fingers_crossed
       action_level: ERROR
-      passthru_level: DEBUG # DEV setting: this means that all message of level DEBUG or higher are always logged
-      #passthru_level: NOTICE # PROD setting this means that all message of level NOTICE or higher are always logged
+      passthru_level: DEBUG
       handler: main_syslog
       bubble: true
       channels: ["!authentication"] # the auth channel is logged by the next handler
     main_syslog:
-      type: syslog
-      ident: stepup-gateway
-      facility: user
+      type: stream
+      path: "php://stderr"
       formatter: surfnet_stepup.monolog.json_formatter
     authenthentication_syslog:
-      type: syslog
-      ident: stepup-authentication
-      facility: user
-      level: INFO
+      type: stream
+      path: "php://stderr"
       channels: [authentication]
       formatter: gateway.monolog.gelf_to_string_formatter
     main_logfile:
       type: stream
       handler: logfile
       level: NOTICE
-      path: "%kernel.logs_dir%/%kernel.environment%.log"
+      path: "%kernel.logs_dir%/dev.log"

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -356,7 +356,7 @@ class SecondFactorController extends Controller
 
         $context->markSecondFactorVerified();
         $this->getAuthenticationLogger()->logSecondFactorAuthentication($originalRequestId, $authenticationMode);
-        $context->setVerifiedBySsoOn2faCookie(null);
+
         $logger->info(sprintf(
             'Marked GSSF "%s" as verified, forwarding to Gateway controller to respond',
             $selectedSecondFactor

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -361,7 +361,6 @@ class SecondFactorController extends Controller
             'Marked GSSF "%s" as verified, forwarding to Gateway controller to respond',
             $selectedSecondFactor
         ));
-        $context->finalizeAuthentication();
         return $this->forward($context->getResponseAction());
     }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/GlobalViewParameters.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/GlobalViewParameters.php
@@ -55,8 +55,12 @@ final class GlobalViewParameters
     /**
      * @return string
      */
-    public function getSupportUrl()
+    public function getSupportUrl(): string
     {
-        return $this->supportUrl[$this->translator->getLocale()];
+        $locale = $this->translator->getLocale();
+        if (array_key_exists($locale, $this->supportUrl)) {
+            return $this->supportUrl[$locale];
+        }
+        return '';
     }
 }

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
@@ -131,6 +131,13 @@ class SecondFactorOnlyController extends Controller
 
         // Reset state
         $this->getSecondFactorRespondService()->resetRespondState($responseContext);
+
+        // Handle SAML response
+        $httpResponse =  $responseRendering->renderResponse($responseContext, $response, $request);
+
+        $ssoCookieService = $this->get('gateway.service.sso_2fa_cookie');
+        $ssoCookieService->handleSsoOn2faCookieStorage($responseContext, $request, $httpResponse, 'sfo');
+
         // We can now forget the selected second factor.
         $responseContext->finalizeAuthentication();
 
@@ -152,8 +159,7 @@ class SecondFactorOnlyController extends Controller
             );
         }
 
-        // Handle SAML response
-        return $responseRendering->renderResponse($responseContext, $response, $request);
+        return $httpResponse;
     }
 
     /**


### PR DESCRIPTION
1. The resetting of the 2FA sso verification state was moved to the response sent action. The caused the removal of the setVerifiedBySsoOn2faCookie method. But the GSSP verified action still called it
2. The SFO authentication did not yet set the SSO cookie (when applicable)
3. The final 2 commits deal with 2 smaller issues.

For tests, see: https://www.pivotaltracker.com/story/show/185989315