### PR TITLE
Require step up auth when cookie is broken

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/CookieServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/CookieServiceTest.php
@@ -666,6 +666,34 @@ class CookieServiceTest extends TestCase
         );
     }
 
+    public function test_reading_cookie_can_fail()
+    {
+        $this->buildService(
+            new Configuration(
+                'test-cookie',
+                'session',
+                0,
+                '0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f'
+            )
+        );
+        $yubikey = $this->buildSecondFactor(3.0, 'identifier-1');
+        $collection = new ArrayCollection([
+            $yubikey,
+        ]);
+        $httpRequest = new Request();
+        $httpRequest->cookies->add([$this->configuration->getName() => 'thiscookieisbroken']);
+
+        self::assertFalse(
+            $this->service->shouldSkip2faAuthentication(
+                $this->responseContext,
+                3.0,
+                'abcdef-1234',
+                $collection,
+                $httpRequest
+            )
+        );
+    }
+
     private function cookieValue(): CookieValue
     {
         $secondFactor = Mockery::mock(SecondFactor::class);


### PR DESCRIPTION
When the cookie can not be decrypted. Or is otherwise broken, missing, or has gone fishing. The requirement was that the end user is asked for a new step up authentication. Previously this would only be the case when the cookie could not be found. Now the other scenarios when a cookie can't be read is are also deferred to that behavior. Previously a 500 error would be served to the user.

See: https://www.pivotaltracker.com/story/show/183402734/comments/238279428