### PR TITLE
Refine log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.2
+Further SSO on 2FA refinements:
+- Set SameSite response header to None #298
+
 ## 4.2.1
 Refinements and bugfixes surrounding the SSO on 2FA
 - Require step up auth when cookie is broken #296

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Changelog
 
-## 4.2.2
-Further SSO on 2FA refinements:
-- Set SameSite response header to None #298
-
 ## 4.2.1
 Refinements and bugfixes surrounding the SSO on 2FA
 - Require step up auth when cookie is broken #296
 - Address some remaining SSO on 2FA issues #295
+- Set SameSite response header to None #298
+- Refine log messages #299 #300
 
 ## 4.2.0
 - Introduction of the SSO on 2FA feature in Stepup-Middleware

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
@@ -97,7 +97,7 @@ class CookieService implements CookieServiceInterface
         if (!$remoteSp->allowedToSetSsoCookieOn2fa()) {
             $this->logger->notice(
                 sprintf(
-                    'Ignoring SSO on 2FA for SP: %s',
+                    'SP: %s does not allow writing SSO on 2FA cookies',
                     $remoteSp->getEntityId()
                 )
             );
@@ -227,7 +227,7 @@ class CookieService implements CookieServiceInterface
         return $this->cookieHelper->fingerprint($request);
     }
 
-    private function shouldAddCookie(CookieValueInterface $ssoCookie, float $loa)
+    private function shouldAddCookie(CookieValueInterface $ssoCookie, float $loa): bool
     {
         // IF the SSO cookie is not found (we've got a NullCookieValue returned from the cookie helper)
         $cookieNotSet = $ssoCookie instanceof NullCookieValue;

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Http/CookieHelper.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Http/CookieHelper.php
@@ -29,6 +29,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CookieHelper implements CookieHelperInterface
 {
+    private const SAME_SITE = Cookie::SAMESITE_NONE;
+
     /**
      * @var Configuration
      */
@@ -100,7 +102,7 @@ class CookieHelper implements CookieHelperInterface
             true,
             true,
             false,
-            Cookie::SAMESITE_STRICT
+            self::SAME_SITE
         );
     }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/CookieServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/CookieServiceTest.php
@@ -19,7 +19,6 @@
 namespace Surfnet\StepupGateway\GatewayBundle\Test\Sso2fa;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -35,7 +34,6 @@ use Surfnet\StepupGateway\GatewayBundle\Service\SecondFactorService;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\CookieService;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Crypto\CryptoHelper;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Crypto\HaliteCryptoHelper;
-use Surfnet\StepupGateway\GatewayBundle\Sso2fa\DateTime\ExpirationHelper;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\DateTime\ExpirationHelperInterface;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Http\CookieHelper;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\Configuration;
@@ -67,14 +65,6 @@ class CookieServiceTest extends TestCase
      * @var InstitutionConfigurationService&Mockery\MockInterface
      */
     private $institutionService;
-    /**
-     * @var LoaResolutionService&Mockery\MockInterface
-     */
-    private $gwLoaResolution;
-    /**
-     * @var SfoLoaResolutionService&Mockery\MockInterface
-     */
-    private $sfoLoaResolution;
     /**
      * @var SecondFactorService&Mockery\MockInterface
      */
@@ -182,6 +172,8 @@ class CookieServiceTest extends TestCase
         // The name and lifetime of the cookie should match the one we configured it to be
         self::assertEquals($this->configuration->getName(), $cookie->getName());
         self::assertEquals($this->configuration->getLifetime(), $cookie->getExpiresTime());
+        // By default we set same-site header to none
+        self::assertEquals(Cookie::SAMESITE_NONE, $cookie->getSameSite());
     }
 
     public function test_storing_a_persistent_cookie()


### PR DESCRIPTION
The message was changed to: 

`SP: https://my-sp.example.org/metadata does not allow writing SSO on 2FA cookies`

See: https://www.pivotaltracker.com/story/show/186011523