### PR TITLE
Clean up unused, and confusing parameter

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/ResponseRenderingService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/ResponseRenderingService.php
@@ -145,7 +145,7 @@ final class ResponseRenderingService
             )
         );
 
-        $this->ssoCookieService->handleSsoOn2faCookieStorage($context, $request, $httpResponse, 'sfo');
+        $this->ssoCookieService->handleSsoOn2faCookieStorage($context, $request, $httpResponse);
         return $httpResponse;
     }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
@@ -102,6 +102,8 @@ class CookieService implements CookieServiceInterface
             );
             return $httpResponse;
         }
+
+        // The second factor id is read from state. It is the SF Id of the token used during authentication
         $secondFactorId = $responseContext->getSelectedSecondFactor();
 
         // We can only set an SSO on 2FA cookie if a second factor authentication is being handled.

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
@@ -89,8 +89,7 @@ class CookieService implements CookieServiceInterface
     public function handleSsoOn2faCookieStorage(
         ResponseContext $responseContext,
         Request $request,
-        Response $httpResponse,
-        string $authenticationMode = 'sso'
+        Response $httpResponse
     ): Response {
         // Check if this specific SP is configured to allow setting of a SSO on 2FA cookie (configured in MW config)
         $remoteSp = $this->getRemoteSp($responseContext);

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
@@ -136,7 +136,7 @@ class SecondFactorOnlyController extends Controller
         $httpResponse =  $responseRendering->renderResponse($responseContext, $response, $request);
 
         $ssoCookieService = $this->get('gateway.service.sso_2fa_cookie');
-        $ssoCookieService->handleSsoOn2faCookieStorage($responseContext, $request, $httpResponse, 'sfo');
+        $ssoCookieService->handleSsoOn2faCookieStorage($responseContext, $request, $httpResponse);
 
         // We can now forget the selected second factor.
         $responseContext->finalizeAuthentication();


### PR DESCRIPTION
The authentication mode was added sometime during development, but was never used. It was historically  used to fetch the correct state handler. But the correct state handler was later injected into the function. The interface did not carry that parameter, so there's that.

Boyscout: added an additional comment, explaining the origin of the second factor id.