### PR TITLE
Simplify cookie write conditions and other improvements

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -126,7 +126,6 @@ class SecondFactorController extends Controller
             $context,
             $requiredLoa->getLevel(),
             $identityNameId,
-            $secondFactorCollection,
             $request
         )) {
             $logger->notice('Skipping second factor authentication. Required LoA was met by the LoA recorded in the cookie');
@@ -354,8 +353,8 @@ class SecondFactorController extends Controller
             );
         }
 
-        $context->markSecondFactorVerified();
         $this->getAuthenticationLogger()->logSecondFactorAuthentication($originalRequestId, $authenticationMode);
+        $context->markSecondFactorVerified();
 
         $logger->info(sprintf(
             'Marked GSSF "%s" as verified, forwarding to Gateway controller to respond',

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -111,7 +111,13 @@ class SecondFactorController extends Controller
             $ssoCookie = $this->getCookieService()->read($request);
             // Test if the SSO cookie can satisfy the second factor authentication requirements
             if ($this->getCookieService()->maySkipAuthentication($requiredLoa->getLevel(), $identityNameId, $ssoCookie)) {
-                $logger->notice('Skipping second factor authentication. Required LoA was met by the LoA recorded in the cookie');
+                $logger->notice(
+                    'Skipping second factor authentication. Required LoA was met by the LoA recorded in the cookie',
+                    [
+                        'required-loa' => $requiredLoa->getLevel(),
+                        'cookie-loa' => $ssoCookie->getLoa()
+                    ]
+                );
                 // We use the SF from the cookie as the SF that was used for authenticating the second factor authentication
                 $secondFactor = $this->getSecondFactorService()->findByUuid($ssoCookie->secondFactorId());
                 $this->getResponseContext($authenticationMode)->saveSelectedSecondFactor($secondFactor);

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
@@ -18,11 +18,9 @@
 
 namespace Surfnet\StepupGateway\GatewayBundle\Sso2fa;
 
-use Doctrine\Common\Collections\Collection;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Surfnet\StepupBundle\Service\SecondFactorTypeService;
-use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor;
 use Surfnet\StepupGateway\GatewayBundle\Entity\ServiceProvider;
 use Surfnet\StepupGateway\GatewayBundle\Exception\RuntimeException;
 use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
@@ -201,7 +199,7 @@ class CookieService implements CookieServiceInterface
         try {
             return $this->cookieHelper->read($request);
         } catch (CookieNotFoundException $e) {
-            $this->logger->notice('Attempt to decrypt the cookie failed, the cookie could not be found');
+            $this->logger->notice('The SSO on 2FA cookie is not found in the request header');
             return new NullCookieValue();
         } catch (DecryptionFailedException $e) {
             $this->logger->notice('Decryption of the SSO on 2FA cookie failed');

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/CookieService.php
@@ -174,7 +174,7 @@ class CookieService implements CookieServiceInterface
         if (!$remoteSp->allowSsoOn2fa()) {
             $this->logger->notice(
                 sprintf(
-                    'Ignoring SSO on 2FA for SP: %s',
+                    'SSO on 2FA is disabled by config for SP: %s',
                     $remoteSp->getEntityId()
                 )
             );

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Crypto/CryptoHelperInterface.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Crypto/CryptoHelperInterface.php
@@ -19,10 +19,11 @@
 namespace Surfnet\StepupGateway\GatewayBundle\Sso2fa\Crypto;
 
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValue;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValueInterface;
 
 interface CryptoHelperInterface
 {
-    public function encrypt(CookieValue $cookieValue): string;
+    public function encrypt(CookieValueInterface $cookieValue): string;
 
     public function decrypt(string $cookieData): CookieValue;
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Crypto/DummyCryptoHelper.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Crypto/DummyCryptoHelper.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupGateway\GatewayBundle\Sso2fa\Crypto;
 
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValue;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValueInterface;
 
 /**
  * Warning! Do not use this helper in a production environment
@@ -27,7 +28,7 @@ use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValue;
  */
 class DummyCryptoHelper implements CryptoHelperInterface
 {
-    public function encrypt(CookieValue $cookieValue): string
+    public function encrypt(CookieValueInterface $cookieValue): string
     {
         return $cookieValue->serialize();
     }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Crypto/HaliteCryptoHelper.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/Crypto/HaliteCryptoHelper.php
@@ -26,6 +26,7 @@ use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Exception\DecryptionFailedExcepti
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\Exception\EncryptionFailedException;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\Configuration;
 use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValue;
+use Surfnet\StepupGateway\GatewayBundle\Sso2fa\ValueObject\CookieValueInterface;
 
 class HaliteCryptoHelper implements CryptoHelperInterface
 {
@@ -47,7 +48,7 @@ class HaliteCryptoHelper implements CryptoHelperInterface
      * derived key, or the secret key input in the HKDF. Encrypting many messages using the same
      * secret key is not a problem in this design.
      */
-    public function encrypt(CookieValue $cookieValue): string
+    public function encrypt(CookieValueInterface $cookieValue): string
     {
         try {
             $plainTextCookieValue = new HiddenString($cookieValue->serialize());

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/CookieValueInterface.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/CookieValueInterface.php
@@ -29,4 +29,6 @@ interface CookieValueInterface
     public function authenticationTime(): int;
 
     public function secondFactorId(): string;
+
+    public function getLoa(): float;
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/NullCookieValue.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Sso2fa/ValueObject/NullCookieValue.php
@@ -44,4 +44,9 @@ class NullCookieValue implements CookieValueInterface
     {
         return '';
     }
+
+    public function getLoa(): float
+    {
+        return 0.0;
+    }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/CookieServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Sso2fa/CookieServiceTest.php
@@ -199,7 +199,7 @@ class CookieServiceTest extends TestCase
 
         $this->logger
             ->shouldReceive('notice')
-            ->with('Ignoring SSO on 2FA for SP: https://remote.sp.stepup.example.com');
+            ->with('SSO on 2FA is disabled by config for SP: https://remote.sp.stepup.example.com');
 
         self::assertFalse($this->service->preconditionsAreMet($this->responseContext));
     }


### PR DESCRIPTION
This PR is a product of the findings found during the second test-a-thon (and the findings found prior to that session)

## Cookie writing pre-conditions were simplified greatly

When:
 - SP allows storing of cookies
 - Institution allows use of the SSO on 2FA feature
 - The user performed an actual 2FA authentication

Then the cookie can be written

Previously other (incorrect) preconditions were checked.

## Bugfix: Higher LoA token is stored in SSO ccokie than the one actually used

See: https://github.com/OpenConext/Stepup-Gateway/pull/302#discussion_r1328626380

## Log improvement

See: https://github.com/OpenConext/Stepup-Gateway/pull/302/commits/4f48b0e9f7a9d6105484b096b0c5b27153c705a7, https://github.com/OpenConext/Stepup-Gateway/pull/302/commits/b7c48f76c913bec1f51b6d9ed9e45fc4f81c2d5e