### PR TITLE
Remove "Stepup Gateway" title from header

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/choose_second_factor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/choose_second_factor.html.twig
@@ -5,7 +5,7 @@
 {% block container_class %}{{ parent() }} wayg{% endblock container_class %}
 
 {% block content %}
-    <h2>{{ block('application_name') }}</h2>
+    <h1>{{ block('application_name') }}</h1>
     {{ form_start(form, {'attr': {'class': 'form-horizontal choose-second-factor-type'}}) }}
 
     {% set formErrors = form.vars.errors.form.getErrors(true) %}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/verify_sms_second_factor_challenge.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/verify_sms_second_factor_challenge.html.twig
@@ -3,7 +3,7 @@
 {% block application_name %}{{ 'gateway.second_factor.sms.verify_challenge.title.page'|trans }}{% endblock application_name %}
 {% block content %}
 
-    <p>{{ 'gateway.second_factor.sms.text.help_user_enter_challenge'|trans }}</p>
+    <h1>{{ 'gateway.second_factor.sms.text.help_user_enter_challenge'|trans }}</h1>
 
     <div class="form-gateway-verify-sms-challenge">
         {{ form_start(form) }}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/verify_yubikey_second_factor.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/second_factor/verify_yubikey_second_factor.html.twig
@@ -20,7 +20,7 @@
     {{ form_end(form) }}
 
 
-    <p>{{ 'gateway.second_factor.yubikey.text.help_user_enter_challenge'|trans }}</p>
+    <h1>{{ 'gateway.second_factor.yubikey.text.help_user_enter_challenge'|trans }}</h1>
     <ol>
         <li>{{ 'gateway.second_factor.yubikey.text.connect_yubikey_to_pc'|trans }}</li>
         <li>{{ 'gateway.second_factor.yubikey.text.ensure_form_field_focus'|trans }}</li>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -51,7 +51,6 @@
     {% block page_header %}
         <div class="page-header clearfix">
             <img src="/images/header-logo.png" class="pull-right logo" alt="OpenConext Stepup">
-            <h1>Stepup Gateway</h1>
         </div>
     {% endblock page_header %}
 


### PR DESCRIPTION
Users don't know what this is, and don't need this information.

Old:
![image](https://github.com/OpenConext/Stepup-Gateway/assets/3096423/a1572dab-5bc2-4a55-a126-e89e831ead08)

New:
![image](https://github.com/OpenConext/Stepup-Gateway/assets/3096423/b4e5420e-6e13-4228-b519-f62f505a9ca4)
![image](https://github.com/OpenConext/Stepup-Gateway/assets/3096423/ca34d61a-51df-45cd-8ecc-a4a3f5aded0d)
![image](https://github.com/OpenConext/Stepup-Gateway/assets/3096423/65ae36a0-4eb2-49a1-a77d-d9ea7ffdaca3)

