### PR TITLE
Verify the GSSP response is valid

### DIFF
--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Saml/StateHandler.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Saml/StateHandler.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupGateway\SamlStepupProviderBundle\Saml;
 
 use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
+use Surfnet\StepupGateway\SamlStepupProviderBundle\Exception\InvalidSubjectException;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 
 class StateHandler extends ProxyStateHandler
@@ -39,12 +40,18 @@ class StateHandler extends ProxyStateHandler
         $this->provider = $provider;
     }
 
-    /**
-     * @param string $subject
-     * @return $this
-     */
-    public function setSubject($subject)
+    public function setSubject(string $subject): self
     {
+        $currentSubject = $this->get('subject');
+        if (!empty($currentSubject) && strtolower($currentSubject) !== strtolower($subject)) {
+            throw new InvalidSubjectException(
+                sprintf(
+                    'The subject should not be rewritten with another value. Old: "%s", new "%s"',
+                    $currentSubject,
+                    $subject
+                )
+            );
+        }
         $this->set('subject', $subject);
 
         return $this;

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
@@ -124,7 +124,7 @@ class SecondFactorOnlyController extends Controller
         }
 
         try {
-            $response = $this->getSecondFactorRespondService()->respond($responseContext);
+            $response = $this->getSecondFactorRespondService()->respond($responseContext, $request);
         } catch (InvalidSecondFactorMethodException $e) {
             throw new BadRequestHttpException($e->getMessage());
         }

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Exception/ReceivedInvalidSubjectNameIdException.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Exception/ReceivedInvalidSubjectNameIdException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2023 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\SecondFactorOnlyBundle\Exception;
+
+use RuntimeException as BaseRuntimeException;
+
+class ReceivedInvalidSubjectNameIdException extends BaseRuntimeException
+{
+
+}

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Resources/config/services.yml
@@ -158,6 +158,13 @@ services:
             - "@second_factor_only.saml_response_factory"
             - "@gateway.service.second_factor_service"
             - "@surfnet_stepup.service.second_factor_type"
+            - '@Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\Gateway\ResponseValidator'
+
+    Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\Gateway\ResponseValidator:
+        arguments:
+            - "@surfnet_stepup.service.second_factor_type"
+            - "@gssp.provider_repository"
+            - "@second_factor_only.http.post_binding"
 
     second_factor_only.adfs_service:
         class: Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\Gateway\AdfsService

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/ResponseValidator.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/ResponseValidator.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Copyright 2023 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\Gateway;
+
+use Surfnet\SamlBundle\Http\PostBinding;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
+use Surfnet\StepupBundle\Value\SecondFactorType;
+use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor;
+use Surfnet\StepupGateway\SamlStepupProviderBundle\Provider\ProviderRepository;
+use Surfnet\StepupGateway\SecondFactorOnlyBundle\Exception\ReceivedInvalidSubjectNameIdException;
+use Symfony\Component\HttpFoundation\Request;
+
+class ResponseValidator
+{
+    /** @var SecondFactorTypeService */
+    private $secondFactorTypeService;
+
+    /** @var ProviderRepository */
+    private $providerRepository;
+
+    /** @var PostBinding  */
+    private $postBinding;
+
+    public function __construct(
+        SecondFactorTypeService $secondFactorTypeService,
+        ProviderRepository $providerRepository,
+        PostBinding $postBinding
+    ) {
+        $this->secondFactorTypeService = $secondFactorTypeService;
+        $this->providerRepository = $providerRepository;
+        $this->postBinding = $postBinding;
+    }
+
+    /**
+     *
+     */
+    public function validate(Request $request, SecondFactor $secondFactor, string $nameIdFromState)
+    {
+        $secondFactorType = new SecondFactorType($secondFactor->secondFactorType);
+        $hasSamlResponse = $request->request->has('SAMLResponse');
+        // When dealing with a GSSP response. It is advised to receive the SAML response through POST Binding,
+        // testing the preconditions.
+        if ($hasSamlResponse && $this->secondFactorTypeService->isGssf($secondFactorType)) {
+            $provider = $this->providerRepository->get($secondFactorType->getSecondFactorType());
+            // Receive the response via POST Binding, this will test all the regular pre-conditions
+            $samlResponse = $this->postBinding->processResponse(
+                $request,
+                $provider->getRemoteIdentityProvider(),
+                $provider->getServiceProvider()
+            );
+            $subjectNameIdFromResponse = $samlResponse->getNameId()->getValue();
+            // Additionally test if the name id from the GSSP matches the SF identifier that we have in state
+            if ($subjectNameIdFromResponse !== $secondFactor->secondFactorIdentifier) {
+                throw new ReceivedInvalidSubjectNameIdException(
+                    sprintf(
+                        'The nameID received from the GSSP (%s) did not match the selected second factor (%s). This '.
+                        'might be an indication someone is tampering with a GSSP. The authentication was started by %s',
+                        $subjectNameIdFromResponse,
+                        $secondFactor->secondFactorIdentifier,
+                        $nameIdFromState
+                    )
+                );
+            }
+        }
+    }
+}

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Tests/Service/Gateway/ResponseValidatorTest.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Tests/Service/Gateway/ResponseValidatorTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\SecondFactorOnlyBundle\Test\Service\Gateway;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use SAML2\Response;
+use SAML2\Response\Exception\PreconditionNotMetException;
+use SAML2\XML\saml\NameID;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Http\PostBinding;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
+use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor;
+use Surfnet\StepupGateway\GatewayBundle\Entity\ServiceProvider;
+use Surfnet\StepupGateway\SamlStepupProviderBundle\Provider\Provider;
+use Surfnet\StepupGateway\SamlStepupProviderBundle\Provider\ProviderRepository;
+use Surfnet\StepupGateway\SamlStepupProviderBundle\Saml\StateHandler;
+use Surfnet\StepupGateway\SecondFactorOnlyBundle\Exception\ReceivedInvalidSubjectNameIdException;
+use Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\Gateway\ResponseValidator;
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ResponseValidatorTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var MockInterface&SecondFactorTypeService */
+    private $secondFactorTypeService;
+
+    /** @var MockInterface&ProviderRepository */
+    private $providerRepository;
+
+    /** @var MockInterface&PostBinding */
+    private $postBinding;
+
+    /** @var MockInterface|IdentityProvider */
+    private $remoteIdp;
+
+    /** @var MockInterface|ServiceProvider */
+    private $sp;
+
+    protected function setUp(): void
+    {
+        $this->secondFactorTypeService = Mockery::mock(SecondFactorTypeService::class);
+        $this->providerRepository = new ProviderRepository();
+        $idp = Mockery::mock(IdentityProvider::class);
+        $this->remoteIdp = Mockery::mock(IdentityProvider::class);
+        $this->sp = Mockery::mock(ServiceProvider::class);
+        $stateHandler = Mockery::mock(StateHandler::class);
+        $provider = new Provider('demo_gssp', $idp, $this->sp, $this->remoteIdp, $stateHandler);
+        $this->providerRepository->addProvider($provider);
+        $this->postBinding = Mockery::mock(PostBinding::class);
+        parent::setUp();
+    }
+
+    public function test_validate_happy_flow()
+    {
+        $request = $this->prepareRequest();
+        $secondFactor = $this->prepareSecondFactor('gssp-identifier');
+        $validator = $this->buildValidator();
+
+        $this->secondFactorTypeService
+            ->shouldReceive('isGssf')
+            ->andReturnTrue();
+
+        $samlResponse = Mockery::mock(Response::class);
+
+        $nameId = Mockery::mock(NameID::class);
+        $nameId->shouldReceive('getValue')
+            ->andReturn('gssp-identifier');
+
+        $samlResponse
+            ->shouldReceive('getNameId')
+            ->andReturn($nameId);
+
+        $this->postBinding
+            ->shouldReceive('processResponse')
+            ->with($request, $this->remoteIdp, $this->sp)
+            ->andReturn($samlResponse);
+
+        $validator->validate($request, $secondFactor, 'sufjan');
+    }
+    public function test_preconditions_must_be_met()
+    {
+        $request = $this->prepareRequest();
+        $secondFactor = $this->prepareSecondFactor('gssp-identifier');
+        $validator = $this->buildValidator();
+
+        $this->secondFactorTypeService
+            ->shouldReceive('isGssf')
+            ->andReturnTrue();
+
+        $this->postBinding
+            ->shouldReceive('processResponse')
+            ->with($request, $this->remoteIdp, $this->sp)
+            ->andThrow(PreconditionNotMetException::class);
+
+        $this->expectException(PreconditionNotMetException::class);
+        $validator->validate($request, $secondFactor, 'sufjan');
+    }
+
+    public function test_validate_response_nameid_must_match_state_nameid()
+    {
+        $request = $this->prepareRequest();
+        $secondFactor = $this->prepareSecondFactor('gssp-identifier');
+        $validator = $this->buildValidator();
+
+        $this->secondFactorTypeService
+            ->shouldReceive('isGssf')
+            ->andReturnTrue();
+
+        $samlResponse = Mockery::mock(Response::class);
+
+        $nameId = Mockery::mock(NameID::class);
+        $nameId->shouldReceive('getValue')
+            ->andReturn('gssp-identifier-changed');
+
+        $samlResponse
+            ->shouldReceive('getNameId')
+            ->andReturn($nameId);
+
+        $this->postBinding
+            ->shouldReceive('processResponse')
+            ->with($request, $this->remoteIdp, $this->sp)
+            ->andReturn($samlResponse);
+
+        $this->expectException(ReceivedInvalidSubjectNameIdException::class);
+        $this->expectExceptionMessage('The nameID received from the GSSP (gssp-identifier-changed) did not match the selected second factor (gssp-identifier). This might be an indication someone is tampering with a GSSP. The authentication was started by sufjan');
+        $validator->validate($request, $secondFactor, 'sufjan');
+    }
+
+    private function buildValidator(): ResponseValidator
+    {
+        return new ResponseValidator($this->secondFactorTypeService, $this->providerRepository, $this->postBinding);
+    }
+
+    private function prepareRequest(): Request
+    {
+        $request = new Request();
+        $requestParams = new InputBag();
+        $requestParams->set('SAMLResponse', 'data');
+        $request->request = $requestParams;
+        return $request;
+    }
+
+    private function prepareSecondFactor(string $identifier): SecondFactor
+    {
+        $secondFactor = Mockery::mock(SecondFactor::class)->makePartial();
+        $secondFactor->secondFactorType = 'demo_gssp';
+        $secondFactor->secondFactorIdentifier = $identifier;
+
+        return $secondFactor;
+    }
+}


### PR DESCRIPTION
Improve the GSSP response handling. The response is now actually read from the POST vars, to verify the preconditions. In addition we verify if the Subject NameID from the response matches with the one found in the AuthNRequest.