### PR TITLE
Fix missing negation in test for issuing "failed" log message

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -209,7 +209,7 @@ class GatewayController extends Controller
         if ($responseHelper->isAdfsResponse($inResponseTo)) {
             $adfsParameters = $responseHelper->retrieveAdfsParameters();
             $logMessage = 'Responding with additional ADFS parameters, in response to request: "%s", with view: "%s"';
-            if ($response->isSuccess()) {
+            if (!$response->isSuccess()) {
                 $logMessage = 'Responding with an AuthnFailed SamlResponse with ADFS parameters, in response to AR: "%s", with view: "%s"';
             }
             $logger->notice(sprintf($logMessage, $inResponseTo, $view));

--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/ResponseRenderingService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/ResponseRenderingService.php
@@ -129,7 +129,7 @@ final class ResponseRenderingService
         $inResponseTo = $context->getInResponseTo();
         if ($this->responseHelper->isAdfsResponse($inResponseTo)) {
             $logMessage = 'Responding with additional ADFS parameters, in response to request: "%s", with view: "%s"';
-            if ($response->isSuccess()) {
+            if (!$response->isSuccess()) {
                 $logMessage = 'Responding with an AuthnFailed SamlResponse with ADFS parameters, in response to AR: "%s", with view: "%s"';
             }
             $this->logger->notice(sprintf($logMessage, $inResponseTo, $view));

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Controller/SamlProxyController.php
@@ -289,7 +289,7 @@ class SamlProxyController extends Controller
         if ($isAdfsResponse) {
             $adfsParameters = $responseHelper->retrieveAdfsParameters();
             $logMessage = 'Responding with additional ADFS parameters, in response to request: "%s", with view: "%s"';
-            if ($response->isSuccess()) {
+            if (!$response->isSuccess()) {
                 $logMessage = 'Responding with an AuthnFailed SamlResponse with ADFS parameters, in response to AR: "%s", with view: "%s"';
             }
             $logger->notice(sprintf($logMessage, $inResponseTo, $view));


### PR DESCRIPTION
The code checks if the response `isSuccess` but then changes the log message to that the response is failed. This is likely a missing negation in the test.

Note: this is from reading the code, I did not perform actual tests on the before and after situation.