### PR TITLE
Ensure consume_assertion.html.twig is rendered once

### DIFF
--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/AdfsService.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/AdfsService.php
@@ -77,15 +77,13 @@ class AdfsService
     }
 
     /**
-     * This method detectds if we need to return a ADFS response, If so ADFS parameters are returned.
+     * This method detects if we need to return a ADFS response, If so ADFS parameters are returned.
      *
      * Second factor verification handled by SecondFactorController is
      * finished. The user was forwarded back to this action with an internal
      * redirect. This method sends a AuthnResponse back to the service
      * provider in response to the AuthnRequest received in ssoAction().
      *
-     * @param LoggerInterface $logger
-     * @param ResponseContext $responseContext
      * @return null|\Surfnet\StepupGateway\SecondFactorOnlyBundle\Adfs\ValueObject\Response
      * @throws InvalidAdfsResponseException
      */


### PR DESCRIPTION
Previously we would always render the regular consume_assertion.html.twig template, and additionally render the adfs variant when dealing with an ADFS response. That caused the JS from not ending up in the template, as Twig concluded that the (reused) JS was already on the page (as it was just rendered).

This ensures the render method is called only once. Circumventing the problem. But not realy solving the issue at hand. Which is that the controller logic is getting growingly more complex and harder to understand.

For that problem, I'm opening a [technical debt issue in Pivotal](https://www.pivotaltracker.com/story/show/186717176).

See: https://github.com/OpenConext/Stepup-Gateway/issues/312
TD ticket: https://www.pivotaltracker.com/story/show/186717176