### PR TITLE
Implode param mixup breaks ADFS authentications

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/ServiceProvider.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/ServiceProvider.php
@@ -101,7 +101,7 @@ class ServiceProvider extends BaseServiceProvider
                     'AuthnRequest requests ACS location "%s" but it is not configured in the list of allowed ACS ' .
                     'locations, allowed locations include: [%s]',
                     $acsLocationInAuthnRequest,
-                    is_string($allowedAcsLocations) ? $allowedAcsLocations : implode($allowedAcsLocations, ', ')
+                    is_string($allowedAcsLocations) ? $allowedAcsLocations : implode(', ', $allowedAcsLocations)
                 )
             );
         }


### PR DESCRIPTION
As noticed by @pmeulen: (copy paste from our Slack) Excuse me for posting this in Dutch

> Exceptie (Uncaught Error: implode(): Argument #2 ($array) must be of type ?array) bij het bouwen van een SFO Response voor een ADFS authenticatie in Gateway 5.0.0

> Dit gaat mis in de laatste stap. De Tiqr GSSP heeft een SAML Respons teruggestuurd en de gateway moet nu een SAML Response voor ADFS gaan maken. Wat mij opvalt in de log is dat het Tiqr GSSP SAML Response twee maal gevalideerd word. Bij of na de tweede validatie gaat het mis.

This PR fixes the failing implode call. Does not address/investigate the double verification of the SAML response.