### PR TITLE
Refrain from rendering a non existing template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.0.2
+- Bugfix: set the correct response Twig template when rendering the ADFS response #333 
+
 ## 5.0.1
 - Bugfix: implode was called with the wrong argument sequence. Which would work in PHP<8.0 #332
 

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,9 @@
             "@phpstan",
             "@phpcs",
             "@phpmd",
-            "@test"
+            "@test",
+            "@behat-adfs",
+            "@behat-metadata"
         ],
         "phplint": "./ci/qa/phplint",
         "validate-lockfile": "./ci/qa/validate",
@@ -111,6 +113,8 @@
         "phpstan": "./ci/qa/phpstan",
         "phpmd": "./ci/qa/phpmd",
         "behat": "./ci/qa/behat",
+        "behat-adfs": "./ci/qa/behat tests/features/adfs.feature",
+        "behat-metadata": "./ci/qa/behat tests/features/metadata.feature",
         "behat-selenium": "./ci/qa/behat-selenium",
         "test": "./ci/qa/phpunit",
         "license-headers": "./ci/qa/docheader",

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
@@ -232,9 +232,11 @@ class ResponseContext
      */
     public function getNormalizedSchacHomeOrganization(): ?string
     {
-        return strtolower(
-            $this->stateHandler->getSchacHomeOrganization()
-        );
+        $schacHomeOrganization = $this->stateHandler->getSchacHomeOrganization();
+        if ($schacHomeOrganization === null) {
+            return null;
+        }
+        return strtolower($schacHomeOrganization);
     }
 
     /**

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Controller/SecondFactorOnlyController.php
@@ -146,7 +146,7 @@ class SecondFactorOnlyController extends ContainerController
             $xmlResponse = $responseRendering->getResponseAsXML($response);
 
             $httpResponse = $this->render(
-                '@SurfnetStepupGatewaySecondFactorOnly/adfs/consume_assertion.html.twig',
+                '@default/adfs/consume_assertion.html.twig',
                 [
                     'acu' => $responseContext->getDestinationForAdfs(),
                     'samlResponse' => $xmlResponse,

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -162,6 +162,9 @@ class FeatureContext implements Context
     public function iEnterTheSmsVerificationCode(): void
     {
         $cookieValue = $this->minkContext->getSession()->getDriver()->getCookie('smoketest-sms-service');
+        if ($cookieValue === null) {
+            throw new RuntimeException('Unable to load the smoketest-sms-service cookie');
+        }
         $matches = [];
         preg_match('/^Your\ SMS\ code:\ (.*)$/', $cookieValue, $matches);
         $this->minkContext->fillField('gateway_verify_sms_challenge_challenge', $matches[1]);


### PR DESCRIPTION
The old Twig naming convention was not updated for the ADFS consume assertion twig template.

This should be the last instance where this was not updated in the Gateway