### PR TITLE
Use getter to access private property

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/EventListener/SecondFactorLocaleListener.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/EventListener/SecondFactorLocaleListener.php
@@ -60,7 +60,7 @@ final class SecondFactorLocaleListener implements EventSubscriberInterface
 
         $secondFactor = $this->secondFactorService->findByUuid($secondFactorId);
         if ($secondFactor) {
-            return $secondFactor->displayLocale;
+            return $secondFactor->getDisplayLocale();
         }
     }
 


### PR DESCRIPTION
Fixes: `Uncaught PHP Exception Error: "Cannot access private property Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\Gateway\SecondfactorGsspFallback::$displayLocale" at SecondFactorLocaleListener.php line 63","context":{"exception":{"class":"Error","message":"Cannot access private property Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\Gateway\SecondfactorGsspFallback::$displayLocale","code":0,"file":"/var/www/html/src/Surfnet/StepupGateway/GatewayBundle/EventListener/SecondFactorLocaleListener.php:63"}`

See: https://github.com/OpenConext/Stepup-Gateway/blob/2712a30a12f54d9184b5ab0e53336c0dcd972593/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/SecondfactorGsspFallback.php#L28