### PR TITLE
Handle missing UserAttributes gracefully

### DIFF
--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/GsspFallbackService.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/GsspFallbackService.php
@@ -70,6 +70,11 @@ class GsspFallbackService
             $subject = $gsspUserAttributes->getAttributeValue($this->config->getSubjectAttribute());
             $institution = $gsspUserAttributes->getAttributeValue($this->config->getInstitutionAttribute());
 
+            if (!is_string($subject) || !is_string($institution)) {
+                $logger->notice('GSSP extension found, but subject and/or institution user attribute(s) are not set');
+                return; // Only set if both attributes are present
+            }
+
             $logger->info(
                 sprintf(
                     'GSSP extension found, setting user attributes in state: subject: %s, institution: %s',


### PR DESCRIPTION
If the UserAttribute with the subject or institution is missing from the AuthnRequest, this gives an TypeError because the attributes are NULL when they're not found:

```
{"message":"Uncaught PHP Exception TypeError: \"Surfnet\\StepupGateway\\GatewayBundle\\Saml\\Proxy\\ProxyStateHandler::setGsspUserAttributes(): Argument #1 ($subject) must be of type string, null given, called in /var/www/html/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/GsspFallbackService.php on line 81\" at ProxyStateHandler.php line 210","context":{"exception":{"class":"TypeError","message":"Surfnet\\StepupGateway\\GatewayBundle\\Saml\\Proxy\\ProxyStateHandler::setGsspUserAttributes(): Argument #1 ($subject) must be of type string, null given, called in /var/www/html/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/GsspFallbackService.php on line 81","code":0,"file":"/var/www/html/src/Surfnet/StepupGateway/GatewayBundle/Saml/Proxy/ProxyStateHandler.php:210"}
```

This PR addresses this issue by ignoring the UserAttributes unless both are present and logging a notice.